### PR TITLE
#14 add possibility to cancel requests

### DIFF
--- a/Sources/Jetworking/Client.swift
+++ b/Sources/Jetworking/Client.swift
@@ -21,7 +21,8 @@ public final class Client {
     }
 
     // MARK: - Methods
-    public func get<ResponseType>(endpoint: Endpoint<ResponseType>, _ completion: @escaping (Result<ResponseType, Error>) -> Void) {
+    @discardableResult
+    public func get<ResponseType>(endpoint: Endpoint<ResponseType>, _ completion: @escaping (Result<ResponseType, Error>) -> Void) -> CancellableRequest? {
         do {
             let request: URLRequest = try createRequest(forHttpMethod: .GET, and: endpoint)
             let dataTask = session.dataTask(with: request) { [weak self] data, urlResponse, error in
@@ -29,12 +30,17 @@ public final class Client {
             }
 
             dataTask.resume()
+
+            return dataTask
         } catch {
             completion(.failure(error))
         }
+
+        return nil
     }
 
-    public func post<BodyType: Encodable, ResponseType>(endpoint: Endpoint<ResponseType>, body: BodyType, _ completion: @escaping (Result<ResponseType, Error>) -> Void) {
+    @discardableResult
+    public func post<BodyType: Encodable, ResponseType>(endpoint: Endpoint<ResponseType>, body: BodyType, _ completion: @escaping (Result<ResponseType, Error>) -> Void) -> CancellableRequest? {
         do {
             let request: URLRequest = try createRequest(forHttpMethod: .POST, and: endpoint)
             let bodyData: Data = try clientConfiguration.encoder.encode(body)
@@ -43,12 +49,17 @@ public final class Client {
             }
 
             dataTask.resume()
+
+            return dataTask
         } catch {
             completion(.failure(error))
         }
+
+        return nil
     }
 
-    public func put<BodyType: Encodable, ResponseType>(endpoint: Endpoint<ResponseType>, body: BodyType, _ completion: @escaping (Result<ResponseType, Error>) -> Void) {
+    @discardableResult
+    public func put<BodyType: Encodable, ResponseType>(endpoint: Endpoint<ResponseType>, body: BodyType, _ completion: @escaping (Result<ResponseType, Error>) -> Void) -> CancellableRequest? {
         do {
             let request: URLRequest = try createRequest(forHttpMethod: .PUT, and: endpoint)
             let bodyData: Data = try clientConfiguration.encoder.encode(body)
@@ -57,16 +68,21 @@ public final class Client {
             }
 
             dataTask.resume()
+
+            return dataTask
         } catch {
             completion(.failure(error))
         }
+
+        return nil
     }
 
+    @discardableResult
     public func patch<BodyType: Encodable, ResponseType>(
         endpoint: Endpoint<ResponseType>,
         body: BodyType,
         _ completion: @escaping (Result<ResponseType, Error>) -> Void
-    ) {
+    ) -> CancellableRequest? {
         do {
             let request: URLRequest = try createRequest(forHttpMethod: .PATCH, and: endpoint)
             let bodyData: Data = try clientConfiguration.encoder.encode(body)
@@ -75,12 +91,17 @@ public final class Client {
             }
 
             dataTask.resume()
+
+            return dataTask
         } catch {
             completion(.failure(error))
         }
+
+        return nil
     }
 
-    public func delete<ResponseType>(endpoint: Endpoint<ResponseType>, parameter: [String: Any] = [:], _ completion: @escaping (Result<ResponseType, Error>) -> Void) {
+    @discardableResult
+    public func delete<ResponseType>(endpoint: Endpoint<ResponseType>, parameter: [String: Any] = [:], _ completion: @escaping (Result<ResponseType, Error>) -> Void) -> CancellableRequest? {
         do {
             let request: URLRequest = try createRequest(forHttpMethod: .DELETE, and: endpoint)
             let dataTask = session.dataTask(with: request) { [weak self] data, urlResponse, error in
@@ -88,9 +109,13 @@ public final class Client {
             }
 
             dataTask.resume()
+
+            return dataTask
         } catch {
             completion(.failure(error))
         }
+
+        return nil
     }
 
     private func createRequest<ResponseType>(forHttpMethod httpMethod: HTTPMethod, and endpoint: Endpoint<ResponseType>) throws -> URLRequest {

--- a/Sources/Jetworking/Protocols/CancellableRequest.swift
+++ b/Sources/Jetworking/Protocols/CancellableRequest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Protocol for requests that can be cancelled.
+public protocol CancellableRequest {
+    /// Cancels a request
+    func cancel()
+}
+
+extension URLSessionTask: CancellableRequest {}

--- a/Tests/JetworkingTests/JetworkingTests.swift
+++ b/Tests/JetworkingTests/JetworkingTests.swift
@@ -33,18 +33,7 @@ final class JetworkingTests: XCTestCase {
     }
 
     func testGetRequest() {
-		let configuration = ClientConfiguration(
-            baseURL: URL(string: "https://postman-echo.com")!,
-            requestInterceptors: [
-                AuthenticationRequestInterceptor(authenticationMethod: self.getAuthenticationMethod()),
-                HeaderFieldsRequestInterceptor(headerFields: self.getHeaderFields())
-            ],
-            responseInterceptors: [],
-            encoder: JSONEncoder(),
-            decoder: JSONDecoder()
-        )
-        let client = Client(clientConfiguration: configuration)
-
+        let client = Client(clientConfiguration: makeDefaultClientConfiguration())
         let expectation = self.expectation(description: "Wait for get")
 
         client.get(endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue")) { result in
@@ -63,18 +52,7 @@ final class JetworkingTests: XCTestCase {
     }
 
     func testPostRequest() {
-        let configuration = ClientConfiguration(
-            baseURL: URL(string: "https://postman-echo.com")!,
-            requestInterceptors: [
-                AuthenticationRequestInterceptor(authenticationMethod: .none),
-                HeaderFieldsRequestInterceptor(headerFields: self.getHeaderFields())
-            ],
-            responseInterceptors: [],
-            encoder: JSONEncoder(),
-            decoder: JSONDecoder()
-        )
-        let client = Client(clientConfiguration: configuration)
-
+        let client = Client(clientConfiguration: makeDefaultClientConfiguration())
         let expectation = self.expectation(description: "Wait for post")
 
         let body: Body = .init(foo1: "bar1", foo2: "bar2")
@@ -94,18 +72,7 @@ final class JetworkingTests: XCTestCase {
     }
 
     func testPutRequest() {
-        let configuration = ClientConfiguration(
-            baseURL: URL(string: "https://postman-echo.com")!,
-            requestInterceptors: [
-                AuthenticationRequestInterceptor(authenticationMethod: .none),
-                HeaderFieldsRequestInterceptor(headerFields: self.getHeaderFields())
-            ],
-            responseInterceptors: [],
-            encoder: JSONEncoder(),
-            decoder: JSONDecoder()
-        )
-        let client = Client(clientConfiguration: configuration)
-
+        let client = Client(clientConfiguration: makeDefaultClientConfiguration())
         let expectation = self.expectation(description: "Wait for post")
 
         let body: Body = .init(foo1: "bar1", foo2: "bar2")
@@ -125,18 +92,7 @@ final class JetworkingTests: XCTestCase {
     }
 
     func testPatchRequest() {
-        let configuration = ClientConfiguration(
-            baseURL: URL(string: "https://postman-echo.com")!,
-            requestInterceptors: [
-                AuthenticationRequestInterceptor(authenticationMethod: .none),
-                HeaderFieldsRequestInterceptor(headerFields: self.getHeaderFields())
-            ],
-            responseInterceptors: [],
-            encoder: JSONEncoder(),
-            decoder: JSONDecoder()
-        )
-        let client = Client(clientConfiguration: configuration)
-
+        let client = Client(clientConfiguration: makeDefaultClientConfiguration())
         let expectation = self.expectation(description: "Wait for post")
 
         let body: Body = .init(foo1: "bar1", foo2: "bar2")
@@ -156,17 +112,7 @@ final class JetworkingTests: XCTestCase {
     }
     
     func testDeleteRequest() {
-        let configuration = ClientConfiguration(
-            baseURL: URL(string: "https://postman-echo.com")!,
-            requestInterceptors: [
-                AuthenticationRequestInterceptor(authenticationMethod: .none),
-                HeaderFieldsRequestInterceptor(headerFields: self.getHeaderFields())
-            ],
-            responseInterceptors: [],
-            encoder: JSONEncoder(),
-            decoder: JSONDecoder()
-        )
-        let client = Client(clientConfiguration: configuration)
+        let client = Client(clientConfiguration: makeDefaultClientConfiguration())
 
         let expectation = self.expectation(description: "Wait for post")
 

--- a/Tests/JetworkingTests/URLFactoryTests.swift
+++ b/Tests/JetworkingTests/URLFactoryTests.swift
@@ -69,8 +69,10 @@ final class URLFactoryTests: XCTestCase {
                 withBaseURL: baseURl
             )
             print(url.absoluteString)
+        } catch let error as APIError {
+            XCTAssertEqual(error, .invalidURLComponents)
         } catch {
-            XCTAssertEqual(error as? APIError, APIError.invalidURLComponents)
+            XCTFail("Unexpected error occured!")
         }
     }
 }


### PR DESCRIPTION
This PR is introducing the `CancellableRequest` protocol. Through this protocol we are now able to cancel a current request since a instance of a `CancellableRequest` is returned on each call.

closes #14 