### PR TITLE
Upload task

### DIFF
--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -196,16 +196,18 @@ public final class Client {
     public func upload(
         url: URL,
         fileURL: URL,
+        multipartType: MultipartType,
+        multipartFileContentType: MultipartContentType,
         formData: [String: String],
         progressHandler: UploadHandler.ProgressHandler,
         _ completion: @escaping UploadHandler.CompletionHandler
     ) -> CancellableRequest? {
         let boundary = UUID().uuidString
 
-        guard let multipartData = Data(boundary: boundary, formData: formData, fileURL: fileURL) else { return nil }
+        guard let multipartData = Data(boundary: boundary, formData: formData, fileURL: fileURL, multipartFileContentType: multipartFileContentType) else { return nil }
 
         var request: URLRequest = .init(url: url, httpMethod: .POST)
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("\(multipartType.rawValue); boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         let task = uploadExecutor.upload(request: request, from: multipartData)
         task.flatMap { executingUploads[$0.identifier] = UploadHandler(progressHandler: progressHandler, completionHandler: completion) }

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -207,6 +207,7 @@ public final class Client {
         guard let multipartData = Data(boundary: boundary, formData: formData, fileURL: fileURL, multipartFileContentType: multipartFileContentType) else { return nil }
 
         var request: URLRequest = .init(url: url, httpMethod: .POST)
+        // TODO: Extract into constants
         request.setValue("\(multipartType.rawValue); boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         let task = uploadExecutor.upload(request: request, from: multipartData)

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -50,6 +50,29 @@ public final class Client {
         }
     }()
 
+    private var executingUploads: [Int: UploadHandler] = [:]
+    private lazy var uploadExecutor: UploadExecutor = {
+        switch configuration.uploadExecutorType {
+        case .default:
+            return DefaultUploadExecutor(
+                sessionConfiguration: session.configuration,
+                uploadExecutorDelegate: self
+            )
+
+        case .background:
+            return BackgroundUploadExecutor(
+                sessionConfiguration: session.configuration,
+                uploadExecutorDelegate: self
+            )
+
+        case let .custom(executorType):
+            return executorType.init(
+                sessionConfiguration: session.configuration,
+                uploadExecutorDelegate: self
+            )
+        }
+    }()
+
     // MARK: - Initialisation
     /**
      * Initialises a new client instance with a default url session.
@@ -157,7 +180,38 @@ public final class Client {
         task.flatMap { executingDownloads[$0.identifier] = DownloadHandler(progressHandler: progressHandler, completionHandler: completion) }
         return task
     }
+    
+    public func upload(
+        url: URL,
+        fileURL: URL,
+        progressHandler: UploadHandler.ProgressHandler,
+        _ completion: @escaping UploadHandler.CompletionHandler
+    ) -> CancellableRequest? {
+        let request: URLRequest = .init(url: url, httpMethod: .POST)
+        let task = uploadExecutor.upload(request: request, fromFile: fileURL)
+        task.flatMap { executingUploads[$0.identifier] = UploadHandler(progressHandler: progressHandler, completionHandler: completion) }
+        return task
+    }
 
+    public func upload(
+        url: URL,
+        fileURL: URL,
+        formData: [String: String],
+        progressHandler: UploadHandler.ProgressHandler,
+        _ completion: @escaping UploadHandler.CompletionHandler
+    ) -> CancellableRequest? {
+        let boundary = UUID().uuidString
+
+        guard let multipartData = Data(boundary: boundary, formData: formData, fileURL: fileURL) else { return nil }
+
+        var request: URLRequest = .init(url: url, httpMethod: .POST)
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        let task = uploadExecutor.upload(request: request, from: multipartData)
+        task.flatMap { executingUploads[$0.identifier] = UploadHandler(progressHandler: progressHandler, completionHandler: completion) }
+        return task
+    }
+    
     private func checkForValidDownloadURL(_ url: URL) -> Bool {
         guard let scheme = URLComponents(string: url.absoluteString)?.scheme else { return false }
 
@@ -238,5 +292,21 @@ extension Client: DownloadExecutorDelegate {
     public func downloadExecutor(_ downloadTask: URLSessionDownloadTask, didCompleteWithError error: Error?) {
         // TODO handle response before calling the completion
         executingDownloads[downloadTask.identifier]?.completionHandler(nil, downloadTask.response, error)
+    }
+}
+
+extension Client: UploadExecutorDelegate {
+    public func uploadExecutor(_ uploadTask: URLSessionUploadTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        executingUploads[uploadTask.identifier]?.progressHandler?(totalBytesSent, totalBytesExpectedToSend)
+    }
+    
+    public func uploadExecutor(didFinishWith uploadTask: URLSessionUploadTask) {
+        // TODO handle response before calling the completion
+        executingUploads[uploadTask.identifier]?.completionHandler(uploadTask.response, uploadTask.error)
+    }
+    
+    public func uploadExecutor(_ uploadTask: URLSessionUploadTask, didCompleteWithError error: Error?) {
+        // TODO handle response before calling the completion
+        executingUploads[uploadTask.identifier]?.completionHandler(uploadTask.response, error)
     }
 }

--- a/Sources/Jetworking/Client/Configuration/Configuration.swift
+++ b/Sources/Jetworking/Client/Configuration/Configuration.swift
@@ -9,6 +9,7 @@ public struct Configuration {
     let decoder: JSONDecoder
     let requestExecutorType: RequestExecutorType
     let downloadExecutorType: DownloadExecutorType
+    let uploadExecutorType: UploadExecutorType
 
     /**
      * Initialises a new configuration instance to use within the client.
@@ -20,6 +21,7 @@ public struct Configuration {
      * - Parameter decoder: The decoder to use to decode the response body data before returning it.
      * - Parameter requestExecutorType: The request executor type to use to execute the requests.
      * - Parameter downloadExecutorType: The download executor type to use to execute downloads.
+     * - Parameter uploadExecutorType: The upload executor type to use to execute uploads
      */
     init(
         baseURL: URL,
@@ -28,7 +30,8 @@ public struct Configuration {
         encoder: JSONEncoder,
         decoder: JSONDecoder,
         requestExecutorType: RequestExecutorType = .async,
-        downloadExecutorType: DownloadExecutorType = .default
+        downloadExecutorType: DownloadExecutorType = .default,
+        uploadExecutorType: UploadExecutorType = .default
     ) {
         self.baseURL = baseURL
         self.requestInterceptors = requestInterceptors
@@ -37,5 +40,6 @@ public struct Configuration {
         self.decoder = decoder
         self.requestExecutorType = requestExecutorType
         self.downloadExecutorType = downloadExecutorType
+        self.uploadExecutorType = uploadExecutorType
     }
 }

--- a/Sources/Jetworking/Client/Executor/DownloadExecutor/Background/BackgroundDownloadExecutor.swift
+++ b/Sources/Jetworking/Client/Executor/DownloadExecutor/Background/BackgroundDownloadExecutor.swift
@@ -77,7 +77,9 @@ final class BackgroundDownloadExecutor: NSObject, DownloadExecutor {
      *  The request to be able to cancel it if necessary.
      */
     func download(request: URLRequest) -> CancellableRequest? {
-        return session.downloadTask(with: request)
+        let downloadTask = session.downloadTask(with: request)
+        downloadTask.resume()
+        return downloadTask
     }
 }
 

--- a/Sources/Jetworking/Client/Executor/DownloadExecutor/Default/DefaultDownloadExecutor.swift
+++ b/Sources/Jetworking/Client/Executor/DownloadExecutor/Default/DefaultDownloadExecutor.swift
@@ -4,9 +4,7 @@ final class DefaultDownloadExecutor: NSObject, DownloadExecutor {
     var delegate: DownloadExecutorDelegate?
     var sessionConfiguration: URLSessionConfiguration
 
-    private lazy var session: URLSession = {
-        return .init(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
-    }()
+    private lazy var session: URLSession = .init(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
 
     init(sessionConfiguration: URLSessionConfiguration, downloadExecutorDelegate: DownloadExecutorDelegate) {
         self.sessionConfiguration = sessionConfiguration

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/Background/BackgroundUploadExecutor.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/Background/BackgroundUploadExecutor.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+final class BackgroundUploadExecutor: NSObject, UploadExecutor {
+    var delegate: UploadExecutorDelegate?
+    var sessionConfiguration: URLSessionConfiguration
+
+    private var backgroundIdentifier: String
+    private var isDiscretionary: Bool = false
+    private lazy var session: URLSession = {
+        let configuration: URLSessionConfiguration = .background(
+            withIdentifier: backgroundIdentifier,
+            andIsDiscretionaryFlag: isDiscretionary,
+            andConfiguration: sessionConfiguration
+        )
+        let session: URLSession = .init(configuration: configuration, delegate: self, delegateQueue: nil)
+        return session
+    }()
+
+    init(sessionConfiguration: URLSessionConfiguration, uploadExecutorDelegate: UploadExecutorDelegate) {
+        self.sessionConfiguration = sessionConfiguration
+        self.delegate = uploadExecutorDelegate
+        self.backgroundIdentifier = "com.jamitlabs.jetworking.background"
+        self.isDiscretionary = false
+
+        super.init()
+    }
+
+    /**
+     * # Summary
+     *  Initialises a download executor to download.
+     *
+     * - Parameter sessionConfiguration:
+     *  The session configuration to use within the download executor.
+     * - Parameter downloadExecutorDelegate:
+     *  The delegate to send the download updates to.
+     * - Parameter backgroundIdentifier:
+     *  When having an app extension which also handles download functionality make sure to set different background Identifiers as otherwise problems might occur
+     * - Parameter isDiscretionary:
+     *  When transferring large amounts of data, you are encouraged to set the value of this property to true.
+     *  Doing so lets the system schedule those transfers at times that are more optimal for the device.
+     *  For example, the system might delay transferring large files until the device is plugged in and connected to the network via Wi-Fi.
+     *  Default value is `false`
+     */
+    init(
+        sessionConfiguration: URLSessionConfiguration,
+        uploadExecutorDelegate: UploadExecutorDelegate,
+        backgroundIdentifier: String = "com.jamitlabs.jetworking.background",
+        isDiscretionary: Bool = false
+    ) {
+        self.sessionConfiguration = sessionConfiguration
+        self.delegate = uploadExecutorDelegate
+        self.backgroundIdentifier = backgroundIdentifier
+        self.isDiscretionary = isDiscretionary
+
+        super.init()
+    }
+
+    /**
+     * # Summary
+     *  Uploading the given request with the given session configuration on a separate background session.
+     *
+     * - Parameter request:
+     *  The request to be downloaded.
+     * - Parameter fromFile:
+     *  The path to the file to be uploaded.
+     *
+     * - Returns:
+     *  The request to be able to cancel if necessary.
+     */
+    func upload(request: URLRequest, fromFile fileURL: URL) -> CancellableRequest? {
+        let uploadTask = session.uploadTask(with: request, fromFile: fileURL)
+        uploadTask.resume()
+        return uploadTask
+    }
+
+    /**
+     * # Summary
+     *  Uploading the given request with the given session configuration on a separate background session.
+     *
+     * - Parameter request:
+     *  The request to be uploaded.
+     * - Parameter from:
+     *  The data to be uploaded.
+     *
+     * - Returns:
+     *  The request to be able to cancel if necessary.
+     */
+    func upload(request: URLRequest, from bodyData: Data) -> CancellableRequest? {
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        do {
+            try bodyData.write(to: fileURL)
+        } catch {
+            return nil
+        }
+
+        return upload(request: request, fromFile: fileURL)
+    }
+}
+
+extension BackgroundUploadExecutor: URLSessionTaskDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        guard let uploadTask = task as? URLSessionUploadTask else { return }
+
+        delegate?.uploadExecutor(uploadTask, didSendBodyData: bytesSent, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let uploadTask = task as? URLSessionUploadTask else { return }
+
+        if let error = error {
+            delegate?.uploadExecutor(uploadTask, didCompleteWithError: error)
+        } else {
+            delegate?.uploadExecutor(didFinishWith: uploadTask)
+        }
+    }
+}

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/Background/BackgroundUploadExecutor.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/Background/BackgroundUploadExecutor.swift
@@ -90,6 +90,7 @@ final class BackgroundUploadExecutor: NSObject, UploadExecutor {
         do {
             try bodyData.write(to: fileURL)
         } catch {
+            // TODO: Add error handling.
             return nil
         }
 

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/Default/DefaultUploadExecutor.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/Default/DefaultUploadExecutor.swift
@@ -4,9 +4,7 @@ final class DefaultUploadExecutor: NSObject, UploadExecutor {
     var delegate: UploadExecutorDelegate?
     var sessionConfiguration: URLSessionConfiguration
 
-    private lazy var session: URLSession = {
-        return .init(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
-    }()
+    private lazy var session: URLSession = .init(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
 
     init(sessionConfiguration: URLSessionConfiguration, uploadExecutorDelegate: UploadExecutorDelegate) {
         self.sessionConfiguration = sessionConfiguration

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/Default/DefaultUploadExecutor.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/Default/DefaultUploadExecutor.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+final class DefaultUploadExecutor: NSObject, UploadExecutor {
+    var delegate: UploadExecutorDelegate?
+    var sessionConfiguration: URLSessionConfiguration
+
+    private lazy var session: URLSession = {
+        return .init(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
+    }()
+
+    init(sessionConfiguration: URLSessionConfiguration, uploadExecutorDelegate: UploadExecutorDelegate) {
+        self.sessionConfiguration = sessionConfiguration
+        self.delegate = uploadExecutorDelegate
+
+        super.init()
+    }
+
+    /**
+     * # Summary
+     *  Uploading the given request and file with the given session configuration on a separate session.
+     *
+     * - Parameter request:
+     *  The request to be uploaded.
+     * - Parameter fromFile:
+     *  The URL the file is located.
+     *
+     * - Returns:
+     *  The request to be able to cancel if necessary.
+     */
+    func upload(request: URLRequest, fromFile fileURL: URL) -> CancellableRequest? {
+        let uploadTask = session.uploadTask(with: request, fromFile: fileURL)
+        uploadTask.resume()
+        return uploadTask
+    }
+
+    /**
+     * # Summary
+     *  Uploading the given request and data with the given session configuration on a separate session.
+     *
+     * - Parameter request:
+     *  The request to be uploaded.
+     * - Parameter from:
+     *  The data to be uploaded.
+     *
+     * - Returns:
+     *  The request to be able to cancel if necessary.
+     */
+    func upload(request: URLRequest, from bodyData: Data) -> CancellableRequest? {
+        let uploadTask = session.uploadTask(with: request, from: bodyData)
+        uploadTask.resume()
+        return uploadTask
+    }
+}
+
+extension DefaultUploadExecutor: URLSessionTaskDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        guard let uploadTask = task as? URLSessionUploadTask else { return }
+
+        delegate?.uploadExecutor(uploadTask, didSendBodyData: bytesSent, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let uploadTask = task as? URLSessionUploadTask else { return }
+
+        if let error = error {
+            delegate?.uploadExecutor(uploadTask, didCompleteWithError: error)
+        } else {
+            delegate?.uploadExecutor(didFinishWith: uploadTask)
+        }
+    }
+}

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/Delegate/UploadExecutorDelegate.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/Delegate/UploadExecutorDelegate.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+// The delegate protocol for the `UploadExecutor`.
+public protocol UploadExecutorDelegate: AnyObject {
+    /**
+     * # Summary
+     *  Delegate which gets called when a progress update happens.
+     *
+     * - Parameter uploadTask:
+     *  The upload task the upload is executed on.
+     * - Parameter didSendBodyData:
+     *  The bytes currently send.
+     * - Parameter totalBytesSent:
+     *  The bytes totally sent.
+     * - Parameter totalBytesExpectedToSend:
+     *  The total bytes expected to send.
+     */
+    func uploadExecutor(_ uploadTask: URLSessionUploadTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64)
+
+    /**
+     * # Summary
+     *  Delegate which gets called when an upload did finish.
+     *
+     * - Parameter downloadTask:
+     *  The upload task the upload is executed on..
+     */
+    func uploadExecutor(didFinishWith uploadTask: URLSessionUploadTask)
+
+    /**
+     * # Summary
+     *  Delegate which gets called when an upload fails.
+     *
+     * - Parameter downloadTask:
+     *  The upload task the upload is executed on.
+     * - Parameter didCompleteWithError:
+     *  The error which was thrown while uploading.
+     */
+    func uploadExecutor(_ uploadTask: URLSessionUploadTask, didCompleteWithError error: Error?)
+}

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/UploadExecutor.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/UploadExecutor.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// The protocol an upload executor has to conform to to be used to upload.
+public protocol UploadExecutor: AnyObject {
+    /// The delegate to set to receive updates on uploads.
+    var delegate: UploadExecutorDelegate? { get }
+    /// The session configuration to use to upload.
+    var sessionConfiguration: URLSessionConfiguration { get }
+
+    /**
+     * # Summary
+     *  Initialises an upload executor to upload.
+     *
+     * - Parameter sessionConfiguration:
+     *  The session configuration to use within the upload executor.
+     * - Parameter downloadExecutorDelegate:
+     *  The delegate to send the upload updates to.
+     */
+    init(sessionConfiguration: URLSessionConfiguration, uploadExecutorDelegate: UploadExecutorDelegate)
+
+    /**
+     * # Summary
+     *  Uploading the given request and file.
+     *
+     * - Parameter request:
+     *  The request to be uploaded.
+     * - Parameter fromFile:
+     *  The file to be uploaded.
+     *
+     * - Returns:
+     *  The request to be able to cancel if necessary.
+     */
+    func upload(request: URLRequest, fromFile fileURL: URL) -> CancellableRequest?
+
+    /**
+     * # Summary
+     *  Uploading the given request and data.
+     *
+     * - Parameter request:
+     *  The request to be uploaded.
+     * - Parameter from:
+     *  The data to be uploaded.
+     *
+     * - Returns:
+     *  The request to be able to cancel if necessary.
+     */
+    func upload(request: URLRequest, from bodyData: Data) -> CancellableRequest?
+}

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/UploadExecutorType.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/UploadExecutorType.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// The upload executor currently supported.
+/// - `default` for an execution using the default session configuration
+/// - `background` for an execution using the background session configuration. ATTENTION: This is still a work in progress approach which is not yet tested with an app and should be used with care.
+/// - `custom` for a custom execution of upload requests provided by the caller.
+public enum UploadExecutorType {
+    case `default`
+    case background
+    case custom(UploadExecutor.Type)
+}

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/UploadHandler.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/UploadHandler.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// The handler used to combine progress and completion.
+public struct UploadHandler {
+    /// Typealias for the progress handler which returns the total bytes sent and the total bytes expected to be sent.
+    public typealias ProgressHandler = ((Int64, Int64) -> Void)?
+    /// Typealias for the completion handler which returns either a response or an error.
+    public typealias CompletionHandler = ((URLResponse?, Error?) -> Void)
+
+    /// The progress handler to use to get updates about the progress of the upload.
+    var progressHandler: ProgressHandler
+    /// The completion handler to use to get either the response or an error.
+    var completionHandler: CompletionHandler
+}

--- a/Sources/Jetworking/Extensions/Data+Extension.swift
+++ b/Sources/Jetworking/Extensions/Data+Extension.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Data {
-    init?(boundary: String, formData: [String: String], fileURL: URL) {
+    init?(boundary: String, formData: [String: String], fileURL: URL, multipartFileContentType: MultipartContentType) {
         guard let fileData: Data = try? Data(contentsOf: fileURL) else { return nil }
 
         self.init()
@@ -15,7 +15,7 @@ extension Data {
         let filename: String = fileURL.lastPathComponent
         append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
         append("Content-Disposition: form-data; name=\"fileToUpload\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
-        append("Content-Type: image/png\r\n\r\n".data(using: .utf8)!)
+        append("Content-Type: \(multipartFileContentType.rawValue)\r\n\r\n".data(using: .utf8)!)
         append(fileData)
 
         append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)

--- a/Sources/Jetworking/Extensions/Data+Extension.swift
+++ b/Sources/Jetworking/Extensions/Data+Extension.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension Data {
+    init?(boundary: String, formData: [String: String], fileURL: URL) {
+        guard let fileData: Data = try? Data(contentsOf: fileURL) else { return nil }
+
+        self.init()
+
+        formData.forEach { key, value in
+            append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
+            append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".data(using: .utf8)!)
+            append("\(value)".data(using: .utf8)!)
+        }
+
+        let filename: String = fileURL.lastPathComponent
+        append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
+        append("Content-Disposition: form-data; name=\"fileToUpload\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
+        append("Content-Type: image/png\r\n\r\n".data(using: .utf8)!)
+        append(fileData)
+
+        append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+    }
+}

--- a/Sources/Jetworking/Utility/MultipartContentType.swift
+++ b/Sources/Jetworking/Utility/MultipartContentType.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public enum MultipartContentType: String {
+    case applicationOctetStream = "application/octet-stream"
+    case applicationPDF = "application/pdf"
+    case applicationPKCS8 = "application/pkcs8"
+    case applicationPKCS10 = "application/pkcs10"
+    case applicationPKCS12 = "application/pkcs12"
+    case applicationZip = "application/zip"
+    case applicationGzip = "application/gzip"
+    case applicationJSON = "application/json"
+    case applicationJWT = "application/jwt"
+    case applicationMP4 = "application/mp4"
+    case applicationRTF = "application/rtf"
+    case applicationVCardJSON = "application/vcard+json"
+    case applicationVCardXML = "application/vcard+xml"
+    case applicationXML = "application/xml"
+
+    case audioAAC = "audio/aac"
+    case audioMPEG = "audio/mpeg"
+    case audioVorbis = "audio/vorbis"
+    
+    case imageJPEG = "image/jpeg"
+    case imagePNG = "image/png"
+    case imageSVG = "image/svg+xml"
+    case imageHEIC = "image/heic"
+    case imageTIFF = "image/tiff"
+
+    case textPlain = "text/plain"
+    case textCSV = "text/csv"
+    case textHTML = "text/html"
+    case textMarkdown = "text/markdown"
+    case textRTF = "text/rtf"
+    case textXML = "text/xml"
+
+    case videoMP4 = "video/mp4"
+}

--- a/Sources/Jetworking/Utility/MultipartType.swift
+++ b/Sources/Jetworking/Utility/MultipartType.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public enum MultipartType: String {
+    case formData = "multipart/form-data"
+    case mixed = "multipart/mixed"
+    case byteRanges = "multipart/byteranges"
+    case encrypted = "multipart/encrypted"
+    case headerSet = "multipart/header-set"
+    case multilingual = "multipart/multilingual"
+    case related = "multipart/related"
+    case report = "multipart/report"
+    case signed = "multipart/signed"
+}

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -228,8 +228,12 @@ final class ClientTests: XCTestCase {
         client.download(
             url: url,
             progressHandler: { (totalBytesWritten, totalBytesExpectedToWrite) in
+                XCTAssertTrue(totalBytesWritten <= totalBytesExpectedToWrite)
+
                 let progress = Float(totalBytesWritten) / Float(totalBytesExpectedToWrite)
                 print("Progress \(progress)")
+                XCTAssertTrue(progress > 0.0)
+                XCTAssertTrue(progress <= 1.0)
             }
         ) { localURL, response, error in
             guard let localURL = localURL else { return }
@@ -266,8 +270,12 @@ final class ClientTests: XCTestCase {
             url: url,
             fileURL: fileURL,
             progressHandler: { (bytesSent, bytesExpectedToSend) in
+                XCTAssertTrue(bytesSent <= bytesExpectedToSend)
+
                 let progress = Float(bytesSent) / Float(bytesExpectedToSend)
                 print("Progress \(progress)")
+                XCTAssertTrue(progress > 0.0)
+                XCTAssertTrue(progress <= 1.0)
             }
         ) { _, error in
             guard error == nil else { return XCTFail("Error while uploading file") }
@@ -290,7 +298,7 @@ final class ClientTests: XCTestCase {
             url: url,
             fileURL: fileURL,
             multipartType: .formData,
-            multipartFileContentType: .textPlain,
+            multipartFileContentType: .imagePNG,
             formData: [
                 "reqtype": "fileupload",
                 "userhash": "caa3dce4fcb36cfdf9258ad9c"

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -289,6 +289,8 @@ final class ClientTests: XCTestCase {
         client.upload(
             url: url,
             fileURL: fileURL,
+            multipartType: .formData,
+            multipartFileContentType: .textPlain,
             formData: [
                 "reqtype": "fileupload",
                 "userhash": "caa3dce4fcb36cfdf9258ad9c"

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -254,6 +254,57 @@ final class ClientTests: XCTestCase {
         
         waitForExpectations(timeout: 140.0, handler: nil)
     }
+    func testUploadFile() {
+        let client = Client(configuration: makeDefaultClientConfiguration())
+        let expectation = self.expectation(description: "Wait for upload")
+        
+        let url = URL(string: "https://catbox.moe/user/api.php")!
+        let documentsUrl: URL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let filename = "avatar.png"
+        let fileURL = documentsUrl.appendingPathComponent(filename)
+        client.upload(
+            url: url,
+            fileURL: fileURL,
+            progressHandler: { (bytesSent, bytesExpectedToSend) in
+                let progress = Float(bytesSent) / Float(bytesExpectedToSend)
+                print("Progress \(progress)")
+            }
+        ) { _, error in
+            guard error == nil else { return XCTFail("Error while uploading file") }
+
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
+    
+    func testUploadMultipartData() {
+        let client = Client(configuration: makeDefaultClientConfiguration())
+        let expectation = self.expectation(description: "Wait for upload")
+        
+        let url = URL(string: "https://catbox.moe/user/api.php")!
+        let documentsUrl: URL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let filename = "avatar.png"
+        let fileURL = documentsUrl.appendingPathComponent(filename)
+        client.upload(
+            url: url,
+            fileURL: fileURL,
+            formData: [
+                "reqtype": "fileupload",
+                "userhash": "caa3dce4fcb36cfdf9258ad9c"
+            ],
+            progressHandler: { (bytesSent, bytesExpectedToSend) in
+                let progress = Float(bytesSent) / Float(bytesExpectedToSend)
+                print("Progress \(progress)")
+            }
+        ) { _, error in
+            guard error == nil else { return XCTFail("Error while uploading multipart data") }
+
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
 }
 
 extension ClientTests {

--- a/Tests/JetworkingTests/UtilityTests/DataExtensionTests.swift
+++ b/Tests/JetworkingTests/UtilityTests/DataExtensionTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import Jetworking
+
+final class DataExtensionTests: XCTestCase {
+    func testMultipartDataInitialisation() {
+        let boundary = UUID().uuidString
+        let documentsUrl: URL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let filename = "avatar.png"
+        let fileURL = documentsUrl.appendingPathComponent(filename)
+        let multipartFileContentType: MultipartContentType = .imagePNG
+        let userhashKey: String = "userhash"
+        let userhashValue: String = "caa3dce4fcb36cfdf9258ad9c"
+        let fileuploadKey: String = "reqtype"
+        let fileuploadValue: String = "fileupload"
+        let formData: [String: String] = [
+            fileuploadKey: fileuploadValue,
+            userhashKey: userhashValue
+        ]
+
+        let multipartData = Data(boundary: boundary, formData: formData, fileURL: fileURL, multipartFileContentType: multipartFileContentType)
+
+        XCTAssertNotNil(multipartData)
+        
+        guard let unwrappedMultipartData = multipartData else { return XCTFail() }
+
+        let contentDispositionUserHash: String = "\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"\(userhashKey)\"\r\n\r\n\(userhashValue)"
+        let contentDispositionReqtype: String = "\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"\(fileuploadKey)\"\r\n\r\n\(fileuploadValue)"
+        let contentDispositionFile: String = "\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"fileToUpload\"; filename=\"\(filename)\"\r\nContent-Type: \(multipartFileContentType.rawValue)\r\n\r\n"
+
+        
+        let multipartString = String(decoding: unwrappedMultipartData, as: UTF8.self)
+
+        XCTAssertTrue(multipartString.contains(contentDispositionUserHash))
+        XCTAssertTrue(multipartString.contains(contentDispositionReqtype))
+        XCTAssertTrue(multipartString.contains(contentDispositionFile))
+        XCTAssertTrue(multipartString.hasSuffix("\r\n--\(boundary)--\r\n"))
+    }
+}


### PR DESCRIPTION
# Description
This PR adds the possibility to upload either a file or a multipart data object. There are three options from which to caller can choose from if the upload should be done using the default session or a background session or a custom implementation. **PLEASE NOTE:** The background session handling is currently not working but somehow prepared to be optimised. 

**PLEASE NOTE:** The tests written require a file named `avatar.png` located in the documents directory of your Mac. This has to be changed later but for now if you add a file with this name into the documents directory the tests will succeed.

Closes #35 and closes #13 