### PR TITLE
Allow POST request with empty content

### DIFF
--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -131,6 +131,26 @@ public final class Client {
     }
 
     @discardableResult
+    public func post<ResponseType>(endpoint: Endpoint<ResponseType>, body: ExpressibleByNilLiteral? = nil, _ completion: @escaping RequestCompletion<ResponseType>) -> CancellableRequest? {
+        do {
+            let request: URLRequest = try createRequest(forHttpMethod: .POST, and: endpoint)
+            return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
+                self?.handleResponse(
+                    data: data,
+                    urlResponse: urlResponse,
+                    error: error,
+                    endpoint: endpoint,
+                    completion: completion
+                )
+            }
+        } catch {
+            enqueue(completion(nil, .failure(error)))
+        }
+
+        return nil
+    }
+
+    @discardableResult
     public func put<BodyType: Encodable, ResponseType>(endpoint: Endpoint<ResponseType>, body: BodyType, _ completion: @escaping RequestCompletion<ResponseType>) -> CancellableRequest? {
         do {
             let bodyData: Data = try configuration.encoder.encode(body)

--- a/Sources/Jetworking/Client/Interceptor/Request/EmptyContentHeaderFieldsRequestInterceptor.swift
+++ b/Sources/Jetworking/Client/Interceptor/Request/EmptyContentHeaderFieldsRequestInterceptor.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/**
+ * A request interceptor which sets specific header fields
+ * which are required for a request with content empty.
+ */
+internal final class EmptyContentHeaderFieldsRequestInterceptor: HeaderFieldsRequestInterceptor {
+    /**
+     * # Summary
+     * Static header fields for a request with empty content
+     *
+     * - Content-type:
+     *   Content type must be given as `text/plain` which is compliant with empty content.
+     *   Other type like `application/json` may cause an inconsistency issue
+     *   because empty content is invalid json.
+     *
+     * - Content-length:
+     *   `0` byte for empty content
+     */
+    private static let headerFieldsForEmptyContent = { () -> [String: String] in
+        return [
+            "Content-type": "text/plain",
+            "Content-length": "0"
+        ]
+    }
+
+    convenience init() {
+        self.init(headerFields: Self.headerFieldsForEmptyContent())
+    }
+
+    override public func intercept(_ request: URLRequest) -> URLRequest {
+        var mutatedRequest: URLRequest = request
+
+        // Repalce related header fields with the corresponding values
+        headerFields().forEach { key, value in
+            mutatedRequest.setValue(value, forHTTPHeaderField: key)
+        }
+
+        return mutatedRequest
+    }
+}

--- a/Sources/Jetworking/Client/Interceptor/Request/HeaderFieldsRequestInterceptor.swift
+++ b/Sources/Jetworking/Client/Interceptor/Request/HeaderFieldsRequestInterceptor.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Implementation of a request interceptor which adds header fields to the request.
-public final class HeaderFieldsRequestInterceptor: RequestInterceptor {
-    private var headerFields: () -> [String: String]
+public class HeaderFieldsRequestInterceptor: RequestInterceptor {
+    internal var headerFields: () -> [String: String]
 
     /**
      * # Summary

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -60,6 +60,28 @@ final class ClientTests: XCTestCase {
         waitForExpectations(timeout: 5.0, handler: nil)
     }
 
+    func testPostRequestWithEmptyContent() {
+        let client = Client(configuration: makeDefaultClientConfiguration())
+        let expectation = self.expectation(description: "Wait for post with empty content")
+
+        client.post(endpoint: Endpoints.post, body: nil) { response, result in
+            dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+            switch result {
+                case .failure:
+                    break
+
+                case let .success(resultData):
+                    print(resultData)
+            }
+
+            XCTAssertNotNil(response)
+            XCTAssertEqual(response?.statusCode, 200)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
+
     func testPutRequest() {
         let client = Client(configuration: makeDefaultClientConfiguration())
         let expectation = self.expectation(description: "Wait for post")


### PR DESCRIPTION
## Description
This extends the framework to be able to make a `POST` request with empty content as described in https://github.com/JamitLabs/Jetworking/issues/47

## Note to this PR
When a user make a POST request with empty content, two following header fields of the request are replaced or added:

* ```Content-type: text/plain```
* ```Content-length: 0```