### PR TITLE
Add API for an external request

### DIFF
--- a/Sources/Jetworking/Client/Endpoint/Endpoint.swift
+++ b/Sources/Jetworking/Client/Endpoint/Endpoint.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Endpoint<ResponseType: Decodable> {
+public struct Endpoint<ResponseType> {
     var pathComponents: [String]
     var queryParameters: [String: String?] = [:]
 

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -129,6 +129,39 @@ final class ClientTests: XCTestCase {
         waitForExpectations(timeout: 5.0, handler: nil)
     }
 
+    func testExternalRequest() {
+        let defaultConfiguration = makeDefaultClientConfiguration()
+        let client = Client(configuration: defaultConfiguration)
+
+        let expectation = self.expectation(description: "Wait for an external request")
+
+        let url = try? URLFactory.makeURL(from: Endpoints.delete, withBaseURL: defaultConfiguration.baseURL)
+        guard let targetURL = url else {
+            XCTFail("URL not available")
+            return
+        }
+
+        var request = URLRequest(url: targetURL, httpMethod: .DELETE)
+        request = defaultConfiguration.requestInterceptors.reduce(request) { $1.intercept($0) }
+
+        client.send(request: request) { (response: HTTPURLResponse?, result: Result<Void, Error>) -> Void in
+            dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+            switch result {
+                case .failure:
+                    break
+
+                case let .success(resultData):
+                    print(resultData)
+            }
+
+            XCTAssertNotNil(response)
+            XCTAssertEqual(response?.statusCode, 200)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
+
     func testRequestCancellation() throws {
         let client = Client(configuration: makeDefaultClientConfiguration())
         let expectation = self.expectation(description: "Wait for get")


### PR DESCRIPTION
## Description

This PR includes following updates:
* Extends the framework to be able to send a request object prepared from outside as described in #34
* Add support for a response with `Void` type

## Note
We assume that the request has been properly configured before passing to the framework. Therefore it is no need to be processed by interceptors again.