### PR TITLE
Extend framework for caching mechanism

### DIFF
--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -10,10 +10,11 @@ enum APIError: Error {
 public final class Client {
     public typealias RequestCompletion<ResponseType> = (HTTPURLResponse?, Result<ResponseType, Error>) -> Void
     // MARK: - Properties
+    public private(set) lazy var sessionCache: SessionCache = .init(configuration: configuration)
+
     private let configuration: Configuration
 
     private lazy var session: URLSession = .init(configuration: .default)
-    private lazy var sessionCache: SessionCache = .init(configuration: configuration)
 
     private lazy var requestExecutor: RequestExecutor = {
         switch configuration.requestExecutorType {
@@ -244,7 +245,7 @@ public final class Client {
         // otherwise executes the download request
         if let url = sessionCache.query(URL.self, for: request) {
             let response = sessionCache.queryCachedResponse(for: request)?.response
-            completion(url, response, nil)
+            enqueue(completion(url, response, nil))
             return nil
         } else {
             let task = downloadExecutor.download(request: request)

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -233,6 +233,7 @@ public final class Client {
     @discardableResult
     public func download(
         url: URL,
+        isForced: Bool = false,
         progressHandler: DownloadHandler.ProgressHandler,
         _ completion: @escaping DownloadHandler.CompletionHandler
     ) -> CancellableRequest? {
@@ -241,9 +242,10 @@ public final class Client {
 
         let request: URLRequest = .init(url: url)
 
-        // Performs completion handler immediately with cached URL if available,
+        // Looks up in cache (if no forced download) and
+        // performs completion handler immediately with cached URL if available,
         // otherwise executes the download request
-        if let url = sessionCache.query(URL.self, for: request) {
+        if !isForced, let url = sessionCache.query(URL.self, for: request) {
             let response = sessionCache.queryCachedResponse(for: request)?.response
             enqueue(completion(url, response, nil))
             return nil

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -10,7 +10,7 @@ enum APIError: Error {
 public final class Client {
     public typealias RequestCompletion<ResponseType> = (HTTPURLResponse?, Result<ResponseType, Error>) -> Void
     // MARK: - Properties
-    public private(set) lazy var sessionCache: SessionCache = .init(configuration: configuration)
+    private lazy var sessionCache: SessionCache = .init(configuration: configuration)
 
     private let configuration: Configuration
 

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -243,7 +243,8 @@ public final class Client {
         // Performs completion handler immediately with cached URL if available,
         // otherwise executes the download request
         if let url = sessionCache.query(URL.self, for: request) {
-            completion(url, nil, nil)
+            let response = sessionCache.queryCachedResponse(for: request)?.response
+            completion(url, response, nil)
             return nil
         } else {
             let task = downloadExecutor.download(request: request)

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -255,6 +255,7 @@ public final class Client {
                     completionHandler: completion
                 )
             }
+
             return task
         }
     }

--- a/Sources/Jetworking/Client/Configuration/Configuration.swift
+++ b/Sources/Jetworking/Client/Configuration/Configuration.swift
@@ -10,6 +10,7 @@ public struct Configuration {
     let downloadExecutorType: DownloadExecutorType
     let uploadExecutorType: UploadExecutorType
     let responseQueue: DispatchQueue
+    let cache: URLCache
 
     /// RequestInteceptors stored in `interceptors` property
     public var requestInterceptors: [RequestInterceptor] {
@@ -31,6 +32,7 @@ public struct Configuration {
      * - Parameter requestExecutorType: The request executor type to use to execute the requests.
      * - Parameter downloadExecutorType: The download executor type to use to execute downloads.
      * - Parameter uploadExecutorType: The upload executor type to use to execute uploads
+     * - Parameter cache: A cache object that realizes caching mechanism. IMPORTANT: At least one instance of `SessionCacheInterceptor` is required.
      */
     public init(
         baseURL: URL,
@@ -40,7 +42,8 @@ public struct Configuration {
         requestExecutorType: RequestExecutorType = .async,
         downloadExecutorType: DownloadExecutorType = .default,
         uploadExecutorType: UploadExecutorType = .default,
-        responseQueue: DispatchQueue = .main
+        responseQueue: DispatchQueue = .main,
+        cache: URLCache = .shared
     ) {
         self.baseURL = baseURL
         self.interceptors = interceptors
@@ -50,5 +53,6 @@ public struct Configuration {
         self.downloadExecutorType = downloadExecutorType
         self.uploadExecutorType = uploadExecutorType
         self.responseQueue = responseQueue
+        self.cache = cache
     }
 }

--- a/Sources/Jetworking/Client/Interceptor/Protocol/SessionCacheInterceptor.swift
+++ b/Sources/Jetworking/Client/Interceptor/Protocol/SessionCacheInterceptor.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A type that represents a session cache interceptor used for intercepting a cached response.
+public protocol SessionCacheInterceptor: Interceptor {
+    /**
+     * # Summary
+     * Intercepting the cached response.
+     *
+     * - Parameter cachedResponse: The proposed cached response.
+     *
+     * - Returns: The intercepted cached response.
+     */
+    func intercept(cachedResponse: CachedURLResponse) -> CachedURLResponse
+}

--- a/Sources/Jetworking/Client/Interceptor/SessionCache/DefaultSessionCacheInterceptor.swift
+++ b/Sources/Jetworking/Client/Interceptor/SessionCache/DefaultSessionCacheInterceptor.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Implementation of a session cache interceptor which allows the response data from an `HTTP/HTTPS` request to be temporarily stored.
+public final class DefaultSessionCacheIntercepter: SessionCacheInterceptor {
+    public static let expectedSchemes: [String] = ["http", "https"]
+
+    private(set) var storagePolicy: URLCache.StoragePolicy
+    private var schemes: [String]
+
+    public init(storagePolicy: URLCache.StoragePolicy = .allowedInMemoryOnly, for schemes: [String] = expectedSchemes) {
+        self.storagePolicy = storagePolicy
+        self.schemes = schemes
+    }
+
+    public func intercept(cachedResponse: CachedURLResponse) -> CachedURLResponse {
+        let responseScheme = cachedResponse.response.url?.scheme
+        guard schemes.contains(responseScheme ?? "") else { return cachedResponse }
+
+        return .init(
+            response: cachedResponse.response,
+            data: cachedResponse.data,
+            userInfo: cachedResponse.userInfo,
+            storagePolicy: storagePolicy
+        )
+    }
+}

--- a/Sources/Jetworking/Utility/SessionCache.swift
+++ b/Sources/Jetworking/Utility/SessionCache.swift
@@ -59,6 +59,22 @@ public final class SessionCache {
         }
     }
 
+    /// Queries a `URL` of existing resource item loaded from the given request.
+    ///
+    /// - Parameter request: The URL request whose cached URL response is desired.
+    ///
+    /// Returns: (Optional) A URL of resource item.
+    public func queryResourceItemURL(for request: URLRequest) -> URL? {
+        guard let url = query(URL.self, for: request) else { return nil }
+
+        guard url.isFileURL, (try? url.checkResourceIsReachable()) != true else { return url }
+
+        // Remove cached object if resource item is invalid.
+        cache.removeCachedResponse(for: request)
+
+        return nil
+    }
+
     /// Queries a `CachedURLResponse` object for the given request.
     ///
     /// - Parameter request: The URL request whose cached URL response is desired.

--- a/Sources/Jetworking/Utility/SessionCache.swift
+++ b/Sources/Jetworking/Utility/SessionCache.swift
@@ -59,6 +59,15 @@ final class SessionCache {
         }
     }
 
+    /// Queries a `CachedURLResponse` object for the given request.
+    ///
+    /// - Parameter request: The URL request whose cached URL response is desired.
+    ///
+    /// Returns: (Optional) A cached URL response
+    public func queryCachedResponse(for request: URLRequest) -> CachedURLResponse? {
+        cache.cachedResponse(for: request)
+    }
+
     // MARK: - Store
     /// Stores an object for a specified request included in the given task.
     ///

--- a/Sources/Jetworking/Utility/SessionCache.swift
+++ b/Sources/Jetworking/Utility/SessionCache.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @dynamicMemberLookup
-final class SessionCache {
+public final class SessionCache {
     private let cache: URLCache
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder

--- a/Sources/Jetworking/Utility/SessionCache.swift
+++ b/Sources/Jetworking/Utility/SessionCache.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+@dynamicMemberLookup
+final class SessionCache {
+    private let cache: URLCache
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let interceptors: [SessionCacheInterceptor]
+
+    // MARK: - Initializers
+    /// Creates a `SessionCache` instance with a configuration used within the `Client` instance.
+    ///
+    /// - Parameters:
+    ///   - configuration: A client configuration.
+    convenience init(configuration: Configuration) {
+        self.init(
+            cache: configuration.cache,
+            encoder: configuration.encoder,
+            decoder: configuration.decoder,
+            interceptors: configuration.interceptors.compactMap {
+                $0 as? SessionCacheInterceptor
+            }
+        )
+    }
+
+    /// Creates a `SessionCache` instance in a comprehensive way.
+    ///
+    /// - Parameters:
+    ///   - cache: A `URLCache` instance.
+    ///   - encoder: An encoder for `json` format.
+    ///   - decoder: A decoder for `json` format.
+    ///   - interceptors: A collection of `SessionCacheInterceptor` instances.
+    init(cache: URLCache, encoder: JSONEncoder, decoder: JSONDecoder, interceptors: [SessionCacheInterceptor]) {
+        self.cache = cache
+        self.encoder = encoder
+        self.decoder = decoder
+        self.interceptors = interceptors
+    }
+
+    subscript<T>(dynamicMember keyPath: KeyPath<URLCache, T>) -> T {
+        cache[keyPath: keyPath]
+    }
+
+    // MARK: - Retrieval
+    /// Queries an object with specified type for the given request.
+    ///
+    /// - Parameter dataType: The data type of the cached data.
+    /// - Parameter request: The URL request whose cached URL response is desired.
+    ///
+    /// Returns: (Optional) A cached object.
+    public func query<T: Codable>(_ dataType: T.Type, for request: URLRequest) -> T? {
+        guard let data = cache.cachedResponse(for: request)?.data else { return nil }
+
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            cache.removeCachedResponse(for: request) // Remove on failure
+            return nil
+        }
+    }
+
+    // MARK: - Store
+    /// Stores an object for a specified request included in the given task.
+    ///
+    /// - Parameter object: An object to be cached.
+    /// - Parameter task: The session task whose response is to be cached.
+    public func store<T: Codable>(_ object: T, from task: URLSessionTask) {
+        guard
+            let request = task.originalRequest ?? task.currentRequest,
+            let response = task.response
+        else { return }
+
+        store(object, from: response, for: request)
+    }
+
+    /// Stores an object from a response for a specified request.
+    ///
+    /// - Parameter object: An object to be cached.
+    /// - Parameter response: A response to a URL request.
+    /// - Parameter request: The request for which the cached URL response is being stored.
+    public func store<T: Codable>(_ object: T, from response: URLResponse, for request: URLRequest) {
+        guard let data = try? encoder.encode(object) else { return }
+
+        var cachedResponse = CachedURLResponse(response: response, data: data, storagePolicy: .notAllowed)
+        cachedResponse = interceptors.reduce(cachedResponse) { cachedResponse, interceptor in
+            return interceptor.intercept(cachedResponse: cachedResponse)
+        }
+
+        cache.storeCachedResponse(cachedResponse, for: request)
+    }
+
+    // MARK: - Removal
+    /// Removes cached object corresponding a specified request if any.
+    public func removeObject(for request: URLRequest) {
+        cache.removeCachedResponse(for: request)
+    }
+
+    /// Removes all cached responses from current storage.
+    public func reset() {
+        cache.removeAllCachedResponses()
+    }
+}

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -401,9 +401,6 @@ final class ClientTests: XCTestCase {
                 // Compares timestamp of each response
                 XCTAssertNotEqual(responseDate, anotherResponseDate)
 
-                // Compares file URL of each download result
-                XCTAssertNotEqual(fileURL, anotherFileURL)
-
                 secondExpectation.fulfill()
             }
 

--- a/Tests/JetworkingTests/InterceptorTests/DefaultSessionCacheInterceptorTests.swift
+++ b/Tests/JetworkingTests/InterceptorTests/DefaultSessionCacheInterceptorTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import Jetworking
+
+final class DefaultSessionCacheInterceptorTests: XCTestCase {
+    func testInterceptorWithDefaultSchemes() {
+        let expectedStoragePolicy: URLCache.StoragePolicy = .allowedInMemoryOnly
+        let interceptor = DefaultSessionCacheIntercepter(storagePolicy: expectedStoragePolicy)
+
+        let cachedReponse = makeDefaultCachedURLResponse(urlString: "https://www.domain.com")
+        let interceptedCachedResponse = interceptor.intercept(cachedResponse: cachedReponse)
+        XCTAssertEqual(expectedStoragePolicy, interceptedCachedResponse.storagePolicy)
+    }
+
+    func testInterceptorWithUndefinedScheme() {
+        let expectedStoragePolicy: URLCache.StoragePolicy = .notAllowed
+        let interceptor = DefaultSessionCacheIntercepter(storagePolicy: expectedStoragePolicy)
+
+        let cachedReponse = makeDefaultCachedURLResponse(urlString: "ftp://www.domain.com")
+        let interceptedCachedResponse = interceptor.intercept(cachedResponse: cachedReponse)
+        XCTAssertEqual(expectedStoragePolicy, interceptedCachedResponse.storagePolicy)
+    }
+
+    func testInterceptorWithEmptyScheme() {
+        let expectedStoragePolicy: URLCache.StoragePolicy = .notAllowed
+        let interceptor = DefaultSessionCacheIntercepter(storagePolicy: expectedStoragePolicy, for: [])
+
+        let cachedReponse = makeDefaultCachedURLResponse(urlString: "https://www.domain.com")
+        let interceptedCachedResponse = interceptor.intercept(cachedResponse: cachedReponse)
+        XCTAssertEqual(expectedStoragePolicy, interceptedCachedResponse.storagePolicy)
+    }
+
+    func testInterceptorWithCustomScheme() {
+        let expectedStoragePolicy: URLCache.StoragePolicy = .allowedInMemoryOnly
+        let interceptor = DefaultSessionCacheIntercepter(storagePolicy: expectedStoragePolicy, for: ["ftp"])
+
+        let cachedReponse = makeDefaultCachedURLResponse(urlString: "ftp://www.domain.com")
+        let interceptedCachedResponse = interceptor.intercept(cachedResponse: cachedReponse)
+        XCTAssertEqual(expectedStoragePolicy, interceptedCachedResponse.storagePolicy)
+    }
+}
+
+extension DefaultSessionCacheInterceptorTests {
+    private func makeDefaultCachedURLResponse(urlString: String) -> CachedURLResponse {
+        .init(
+            response: .init(
+                url: URL(string: urlString)!,
+                mimeType: nil,
+                expectedContentLength: 0,
+                textEncodingName: nil
+            ),
+            data: .init(),
+            userInfo: nil,
+            storagePolicy: .notAllowed
+        )
+    }
+}

--- a/Tests/JetworkingTests/UtilityTests/SessionCacheTests.swift
+++ b/Tests/JetworkingTests/UtilityTests/SessionCacheTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import Jetworking
+
+final class SessionCacheTests: XCTestCase {
+    func testSessionCacheQueryForNoCachedData() {
+        let sessionCache: SessionCache = makeDefaultSessionCache()
+
+        // Retrieves cache
+        let cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+
+        XCTAssertNil(cachedData)
+    }
+
+    func testSessionCacheQueryForCachedData() {
+        let sessionCache: SessionCache = makeDefaultSessionCache()
+
+        // Caches something
+        let dataToCache = makeMockBody()
+        sessionCache.store(dataToCache, from: makeSampleResponse(), for: makeSampleReuest())
+
+        // Retrieves cache
+        let cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+
+        XCTAssertNotNil(cachedData)
+        XCTAssertEqual(dataToCache.foo1, cachedData?.foo1)
+        XCTAssertEqual(dataToCache.foo2, cachedData?.foo2)
+    }
+
+    func testSessionCacheQueryForCachedDataWithOtherDataType() {
+        let sessionCache: SessionCache = makeDefaultSessionCache()
+
+        // Caches something
+        sessionCache.store(makeMockBody(), from: makeSampleResponse(), for: makeSampleReuest())
+
+        // Retrieves cached object with expected data type
+        let cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+        XCTAssertNotNil(cachedData)
+
+        // Retrieves cached object with wrong data type
+        let nilCachedData = sessionCache.query(String.self, for: makeSampleReuest())
+        XCTAssertNil(nilCachedData)
+    }
+
+    func testSessionCacheRemoveCachedObject() {
+        let sessionCache: SessionCache = makeDefaultSessionCache()
+
+        // Caches something
+        sessionCache.store(makeMockBody(), from: makeSampleResponse(), for: makeSampleReuest())
+
+        // Ensures cached object's existance
+        var cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+        XCTAssertNotNil(cachedData)
+
+        // Removes cached object
+        sessionCache.removeObject(for: makeSampleReuest())
+
+        // Ensures object removal
+        cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+        XCTAssertNil(cachedData)
+    }
+
+    func testSessionCacheRemoveNonCachedObject() {
+        let sessionCache: SessionCache = makeDefaultSessionCache()
+        let memoryUsage = sessionCache.currentMemoryUsage
+
+        // Removes cached object
+        sessionCache.removeObject(for: makeSampleReuest())
+
+        XCTAssertEqual(memoryUsage, sessionCache.currentMemoryUsage)
+    }
+
+    func testSessionCacheReset() {
+        let sessionCache: SessionCache = makeDefaultSessionCache()
+        XCTAssertTrue(sessionCache.currentMemoryUsage < 1)
+
+        // Caches something
+        sessionCache.store(makeMockBody(), from: makeSampleResponse(), for: makeSampleReuest())
+        XCTAssertTrue(sessionCache.currentMemoryUsage > 1)
+
+        // Removes cached data
+        sessionCache.reset()
+        XCTAssertTrue(sessionCache.currentMemoryUsage < 1)
+
+        let cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+        XCTAssertNil(cachedData)
+    }
+
+}
+
+// MARK: - Factory methods
+extension SessionCacheTests {
+    private func makeMockBody() -> MockBody {
+        .init(foo1: "1", foo2: "2")
+    }
+
+    private func makeSampleReuest() -> URLRequest {
+        .init(url: URL(string: "https://postman-echo.com")!, httpMethod: .GET)
+    }
+
+    private func makeSampleResponse() -> URLResponse {
+        .init(
+            url: URL(string: "https://postman-echo.com")!,
+            mimeType: nil,
+            expectedContentLength: 0,
+            textEncodingName: nil
+        )
+    }
+
+    private func makeDefaultSessionCache() -> SessionCache {
+        return .init(
+            cache: .init(
+                memoryCapacity: 1_024 * 1_024, // 1 MB
+                diskCapacity: .zero,
+                diskPath: nil
+            ),
+            encoder: .init(),
+            decoder: .init(),
+            interceptors: [
+                DefaultSessionCacheIntercepter(storagePolicy: .allowedInMemoryOnly)
+            ]
+        )
+    }
+}

--- a/Tests/JetworkingTests/UtilityTests/SessionCacheTests.swift
+++ b/Tests/JetworkingTests/UtilityTests/SessionCacheTests.swift
@@ -26,6 +26,19 @@ final class SessionCacheTests: XCTestCase {
         XCTAssertEqual(dataToCache.foo2, cachedData?.foo2)
     }
 
+    func testSessionCacheQueryForCachedResponse() {
+        let sessionCache: SessionCache = makeDefaultSessionCache()
+
+        // Caches something
+        let sampleResponse = makeSampleResponse()
+        sessionCache.store(makeMockBody(), from: sampleResponse, for: makeSampleRequest())
+
+        // Retrieves response
+        let cachedResponse = sessionCache.queryCachedResponse(for: makeSampleRequest())
+
+        XCTAssertEqual(cachedResponse?.response, sampleResponse)
+    }
+
     func testSessionCacheQueryForCachedDataWithOtherDataType() {
         let sessionCache: SessionCache = makeDefaultSessionCache()
 

--- a/Tests/JetworkingTests/UtilityTests/SessionCacheTests.swift
+++ b/Tests/JetworkingTests/UtilityTests/SessionCacheTests.swift
@@ -6,7 +6,7 @@ final class SessionCacheTests: XCTestCase {
         let sessionCache: SessionCache = makeDefaultSessionCache()
 
         // Retrieves cache
-        let cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+        let cachedData = sessionCache.query(MockBody.self, for: makeSampleRequest())
 
         XCTAssertNil(cachedData)
     }
@@ -16,10 +16,10 @@ final class SessionCacheTests: XCTestCase {
 
         // Caches something
         let dataToCache = makeMockBody()
-        sessionCache.store(dataToCache, from: makeSampleResponse(), for: makeSampleReuest())
+        sessionCache.store(dataToCache, from: makeSampleResponse(), for: makeSampleRequest())
 
         // Retrieves cache
-        let cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+        let cachedData = sessionCache.query(MockBody.self, for: makeSampleRequest())
 
         XCTAssertNotNil(cachedData)
         XCTAssertEqual(dataToCache.foo1, cachedData?.foo1)
@@ -30,14 +30,14 @@ final class SessionCacheTests: XCTestCase {
         let sessionCache: SessionCache = makeDefaultSessionCache()
 
         // Caches something
-        sessionCache.store(makeMockBody(), from: makeSampleResponse(), for: makeSampleReuest())
+        sessionCache.store(makeMockBody(), from: makeSampleResponse(), for: makeSampleRequest())
 
         // Retrieves cached object with expected data type
-        let cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+        let cachedData = sessionCache.query(MockBody.self, for: makeSampleRequest())
         XCTAssertNotNil(cachedData)
 
         // Retrieves cached object with wrong data type
-        let nilCachedData = sessionCache.query(String.self, for: makeSampleReuest())
+        let nilCachedData = sessionCache.query(String.self, for: makeSampleRequest())
         XCTAssertNil(nilCachedData)
     }
 
@@ -45,17 +45,17 @@ final class SessionCacheTests: XCTestCase {
         let sessionCache: SessionCache = makeDefaultSessionCache()
 
         // Caches something
-        sessionCache.store(makeMockBody(), from: makeSampleResponse(), for: makeSampleReuest())
+        sessionCache.store(makeMockBody(), from: makeSampleResponse(), for: makeSampleRequest())
 
         // Ensures cached object's existance
-        var cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+        var cachedData = sessionCache.query(MockBody.self, for: makeSampleRequest())
         XCTAssertNotNil(cachedData)
 
         // Removes cached object
-        sessionCache.removeObject(for: makeSampleReuest())
+        sessionCache.removeObject(for: makeSampleRequest())
 
         // Ensures object removal
-        cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+        cachedData = sessionCache.query(MockBody.self, for: makeSampleRequest())
         XCTAssertNil(cachedData)
     }
 
@@ -64,7 +64,7 @@ final class SessionCacheTests: XCTestCase {
         let memoryUsage = sessionCache.currentMemoryUsage
 
         // Removes cached object
-        sessionCache.removeObject(for: makeSampleReuest())
+        sessionCache.removeObject(for: makeSampleRequest())
 
         XCTAssertEqual(memoryUsage, sessionCache.currentMemoryUsage)
     }
@@ -74,14 +74,14 @@ final class SessionCacheTests: XCTestCase {
         XCTAssertTrue(sessionCache.currentMemoryUsage < 1)
 
         // Caches something
-        sessionCache.store(makeMockBody(), from: makeSampleResponse(), for: makeSampleReuest())
+        sessionCache.store(makeMockBody(), from: makeSampleResponse(), for: makeSampleRequest())
         XCTAssertTrue(sessionCache.currentMemoryUsage > 1)
 
         // Removes cached data
         sessionCache.reset()
         XCTAssertTrue(sessionCache.currentMemoryUsage < 1)
 
-        let cachedData = sessionCache.query(MockBody.self, for: makeSampleReuest())
+        let cachedData = sessionCache.query(MockBody.self, for: makeSampleRequest())
         XCTAssertNil(cachedData)
     }
 
@@ -93,7 +93,7 @@ extension SessionCacheTests {
         .init(foo1: "1", foo2: "2")
     }
 
-    private func makeSampleReuest() -> URLRequest {
+    private func makeSampleRequest() -> URLRequest {
         .init(url: URL(string: "https://postman-echo.com")!, httpMethod: .GET)
     }
 


### PR DESCRIPTION
## Description

This PR includes following changes:

* Implements caching mechanism (described in #18) by using [`URLCache`](https://developer.apple.com/documentation/foundation/urlcache) 
* Allows custom interceptor(s) for caching.

## Note

* `URLCache` can be easily customized in client's `Configuration`
* Caching requires **at least one** `SessionCacheInterceptor` instance.
* Caching is currently available for **`Download` operation only**.