### PR TITLE
Use postman response to validate body and arguments

### DIFF
--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -17,24 +17,30 @@ final class ClientTests: XCTestCase {
 
         let expectation = self.expectation(description: "Wait for get")
 
-        client.get(endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue")) { response, result in
+        let queryParameter: (key: String, value: String) = (key: "SomeKey", value: "SomeValue")
+        let endpoint: Endpoint<MockResponseForArguments<[String: String]>> = Endpoints.getWithBody()
+        client.get(endpoint: endpoint.addQueryParameter(key: queryParameter.key, value: queryParameter.value)) { response, result in
 
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
 
+            var resultData: [String: String]?
             switch result {
             case .failure:
                 break
 
-            case let .success(resultData):
-                print(resultData)
+            case let .success(data):
+                resultData = data.args
             }
 
             XCTAssertNotNil(response)
             XCTAssertEqual(response?.statusCode, 200)
+            XCTAssertNotNil(resultData)
+            XCTAssertEqual(resultData?.first?.key, queryParameter.key)
+            XCTAssertEqual(resultData?.first?.value, queryParameter.value)
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 5.0, handler: nil) 
+        waitForExpectations(timeout: 5.0, handler: nil)
     }
 
     func testPostRequest() {
@@ -42,18 +48,23 @@ final class ClientTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for post")
 
         let body: MockBody = .init(foo1: "bar1", foo2: "bar2")
-        client.post(endpoint: Endpoints.post, body: body) { response, result in
+        let endpoint: Endpoint<MockResponseForRequestBody<MockBody>> = Endpoints.postWithBody()
+        client.post(endpoint: endpoint, body: body) { response, result in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+            var resultData: MockBody?
             switch result {
             case .failure:
                 break
 
-            case let .success(resultData):
-                print(resultData)
+            case let .success(data):
+                resultData = data.json
             }
 
             XCTAssertNotNil(response)
             XCTAssertEqual(response?.statusCode, 200)
+            XCTAssertNotNil(resultData)
+            XCTAssertEqual(resultData?.foo1, body.foo1)
+            XCTAssertEqual(resultData?.foo2, body.foo2)
             expectation.fulfill()
         }
 
@@ -65,18 +76,23 @@ final class ClientTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for post")
 
         let body: MockBody = .init(foo1: "bar1", foo2: "bar2")
-        client.put(endpoint: Endpoints.put, body: body) { response, result in
+        let endpoint: Endpoint<MockResponseForRequestBody<MockBody>> = Endpoints.putWithBody()
+        client.put(endpoint: endpoint, body: body) { response, result in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+            var resultData: MockBody?
             switch result {
             case .failure:
                 break
 
-            case let .success(resultData):
-                print(resultData)
+            case let .success(data):
+                resultData = data.json
             }
 
             XCTAssertNotNil(response)
             XCTAssertEqual(response?.statusCode, 200)
+            XCTAssertNotNil(resultData)
+            XCTAssertEqual(resultData?.foo1, body.foo1)
+            XCTAssertEqual(resultData?.foo2, body.foo2)
             expectation.fulfill()
         }
 
@@ -88,24 +104,29 @@ final class ClientTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for post")
 
         let body: MockBody = .init(foo1: "bar1", foo2: "bar2")
-        client.patch(endpoint: Endpoints.patch, body: body) { response, result in
+        let endpoint: Endpoint<MockResponseForRequestBody<MockBody>> = Endpoints.patchWithBody()
+        client.patch(endpoint: endpoint, body: body) { response, result in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+            var resultData: MockBody?
             switch result {
             case .failure:
                 break
 
-            case let .success(resultData):
-                print(resultData)
+            case let .success(data):
+                resultData = data.json
             }
 
             XCTAssertNotNil(response)
             XCTAssertEqual(response?.statusCode, 200)
+            XCTAssertNotNil(resultData)
+            XCTAssertEqual(resultData?.foo1, body.foo1)
+            XCTAssertEqual(resultData?.foo2, body.foo2)
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: 5.0, handler: nil)
     }
-    
+
     func testDeleteRequest() {
         let client = Client(configuration: makeDefaultClientConfiguration())
 
@@ -203,7 +224,7 @@ final class ClientTests: XCTestCase {
 
         XCTAssertTrue(result == .completed)
     }
-    
+
     func testIncorrectOrderDueToAsyncRequestExecutor() {
         let client = Client(configuration: makeDefaultClientConfiguration())
 
@@ -225,10 +246,10 @@ final class ClientTests: XCTestCase {
 
         XCTAssertTrue(result == .incorrectOrder)
 	}
-    
+
     func testDownloadWithInvalidURL() {
         let client = Client(configuration: makeDefaultClientConfiguration())
-        
+
         let url = URL(string: "smtp://www.mail.com")!
         let task = client.download(
             url: url,
@@ -274,14 +295,14 @@ final class ClientTests: XCTestCase {
 
             expectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 140.0, handler: nil)
     }
 
     func testUploadFile() {
         let client = Client(configuration: makeDefaultClientConfiguration())
         let expectation = self.expectation(description: "Wait for upload")
-        
+
         let url = URL(string: "https://catbox.moe/user/api.php")!
         let path = Bundle.module.path(forResource: "avatar", ofType: "png")!
         client.upload(
@@ -305,11 +326,11 @@ final class ClientTests: XCTestCase {
 
         waitForExpectations(timeout: 5.0, handler: nil)
     }
-    
+
     func testUploadMultipartData() {
         let client = Client(configuration: makeDefaultClientConfiguration())
         let expectation = self.expectation(description: "Wait for upload")
-        
+
         let url = URL(string: "https://catbox.moe/user/api.php")!
 
         let filePath = Bundle.module.path(forResource: "avatar", ofType: ".png")!

--- a/Tests/JetworkingTests/MockData/Endpoints.swift
+++ b/Tests/JetworkingTests/MockData/Endpoints.swift
@@ -7,4 +7,20 @@ enum Endpoints {
     static let patch: Endpoint<Empty> = .init(pathComponent: "patch")
     static let put: Endpoint<Empty> = .init(pathComponent: "put")
     static let delete: Endpoint<Empty> = .init(pathComponent: "delete")
+
+    static func postWithBody<ResponseBody: Codable>() -> Endpoint<ResponseBody> {
+        return .init(pathComponent: "post")
+    }
+
+    static func getWithBody<ResponseBody: Codable>() -> Endpoint<ResponseBody> {
+        return .init(pathComponent: "get")
+    }
+
+    static func putWithBody<ResponseBody: Codable>() -> Endpoint<ResponseBody> {
+        return .init(pathComponent: "put")
+    }
+
+    static func patchWithBody<ResponseBody: Codable>() -> Endpoint<ResponseBody> {
+        return .init(pathComponent: "patch")
+    }
 }

--- a/Tests/JetworkingTests/MockData/MockResponseForArguments.swift
+++ b/Tests/JetworkingTests/MockData/MockResponseForArguments.swift
@@ -1,0 +1,4 @@
+struct MockResponseForArguments<ArgumentTypes: Codable>: Codable {
+    let args: ArgumentTypes
+    let url: String
+}

--- a/Tests/JetworkingTests/MockData/MockResponseForRequestBody.swift
+++ b/Tests/JetworkingTests/MockData/MockResponseForRequestBody.swift
@@ -1,0 +1,4 @@
+struct MockResponseForRequestBody<RequestBodyType: Codable>: Codable {
+    let json: RequestBodyType
+    let url: String
+}


### PR DESCRIPTION
## Description

For the `post`, `put` and `patch` test request the postman response is compared with the contents of the mock body to check if the body was sent correctly. 

The postman response is also used to check if the arguments of the `get` request were sent correctly.

Solves #55  