### PR TITLE
Don't call download completion handler twice

### DIFF
--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -356,7 +356,10 @@ extension Client: DownloadExecutorDelegate {
 
     public func downloadExecutor(_ downloadTask: URLSessionDownloadTask, didCompleteWithError error: Error?) {
         // TODO handle response before calling the completion
-        guard let completionHandler = executingDownloads[downloadTask.identifier]?.completionHandler else { return }
+        guard
+            let completionHandler = executingDownloads[downloadTask.identifier]?.completionHandler,
+            let error = error
+        else { return }
         enqueue(completionHandler(nil, downloadTask.response, error))
     }
 }

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -255,7 +255,10 @@ final class ClientTests: XCTestCase {
             }
         ) { localURL, response, error in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
-            guard let localURL = localURL else { return }
+            guard let localURL = localURL else {
+                XCTFail("Failed to unwrap url")
+                return
+            }
 
             do {
                 let documentsURL = try FileManager.default.url(


### PR DESCRIPTION
## Description

Evaluates the error in `Client.downloadExecutor(_ downloadTask: URLSessionDownloadTask, didCompleteWithError error: Error?)` to avoid the completion handler call in case the error is nil.

Solves #57 