### PR TITLE
Implement encoding/decoding strategy

### DIFF
--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -16,6 +16,7 @@ public final class Client {
     private let configuration: Configuration
 
     private lazy var session: URLSession = .init(configuration: .default)
+    private lazy var responseHandler: ResponseHandler = .init(configuration: configuration)
 
     private lazy var requestExecutor: RequestExecutor = {
         switch configuration.requestExecutorType {
@@ -99,12 +100,11 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.handleDecodableResponse(
+                self.responseHandler.handleDecodableResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
-                    configuration: self.configuration,
                     completion: completion
                 )
             }
@@ -124,12 +124,11 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.handleDecodableResponse(
+                self.responseHandler.handleDecodableResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
-                    configuration: self.configuration,
                     completion: completion
                 )
             }
@@ -147,12 +146,11 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.handleVoidResponse(
+                self.responseHandler.handleVoidResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
-                    configuration: self.configuration,
                     completion: completion
                 )
             }
@@ -172,12 +170,11 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.handleDecodableResponse(
+                self.responseHandler.handleDecodableResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
-                    configuration: self.configuration,
                     completion: completion
                 )
             }
@@ -201,12 +198,11 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.handleDecodableResponse(
+                self.responseHandler.handleDecodableResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
-                    configuration: self.configuration,
                     completion: completion
                 )
             }
@@ -224,12 +220,11 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.handleDecodableResponse(
+                self.responseHandler.handleDecodableResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
-                    configuration: self.configuration,
                     completion: completion
                 )
             }

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -99,13 +99,12 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.evaluate(
+                ResponseHandler.handleDecodableResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
                     configuration: self.configuration,
-                    completionWrapper: ResponseHandler.CompletionWrapper.decodable,
                     completion: completion
                 )
             }
@@ -125,13 +124,12 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.evaluate(
+                ResponseHandler.handleDecodableResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
                     configuration: self.configuration,
-                    completionWrapper: ResponseHandler.CompletionWrapper.decodable,
                     completion: completion
                 )
             }
@@ -149,13 +147,12 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.evaluate(
+                ResponseHandler.handleVoidResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
                     configuration: self.configuration,
-                    completionWrapper: ResponseHandler.CompletionWrapper.void,
                     completion: completion
                 )
             }
@@ -175,13 +172,12 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.evaluate(
+                ResponseHandler.handleDecodableResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
                     configuration: self.configuration,
-                    completionWrapper: ResponseHandler.CompletionWrapper.decodable,
                     completion: completion
                 )
             }
@@ -205,13 +201,12 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.evaluate(
+                ResponseHandler.handleDecodableResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
                     configuration: self.configuration,
-                    completionWrapper: ResponseHandler.CompletionWrapper.decodable,
                     completion: completion
                 )
             }
@@ -229,13 +224,12 @@ public final class Client {
             return requestExecutor.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
-                ResponseHandler.evaluate(
+                ResponseHandler.handleDecodableResponse(
                     data: data,
                     urlResponse: urlResponse,
                     error: error,
                     endpoint: endpoint,
                     configuration: self.configuration,
-                    completionWrapper: ResponseHandler.CompletionWrapper.decodable,
                     completion: completion
                 )
             }

--- a/Sources/Jetworking/Client/Configuration/Coder/Decoder.swift
+++ b/Sources/Jetworking/Client/Configuration/Coder/Decoder.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public protocol Decoder {
+    /**
+     * Decodes data to an instance of the indicated type.
+     *
+     * - Parameter type:
+     *  The type data is decoded to.
+     * - Parameter data:
+     *  The data to decode.
+     */
+    func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T
+}

--- a/Sources/Jetworking/Client/Configuration/Coder/Encoder.swift
+++ b/Sources/Jetworking/Client/Configuration/Coder/Encoder.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public protocol Encoder {
+    /**
+     * Encodes an instance of the indicated type.
+     *
+     * - Parameter value:
+     *  The enstance to encode.
+     */
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}

--- a/Sources/Jetworking/Client/Configuration/Configuration.swift
+++ b/Sources/Jetworking/Client/Configuration/Configuration.swift
@@ -4,8 +4,8 @@ import Foundation
 public struct Configuration {
     let baseURL: URL
     let interceptors: [Interceptor]
-    let encoder: JSONEncoder
-    let decoder: JSONDecoder
+    let encoder: Encoder
+    let decoder: Decoder
     let requestExecutorType: RequestExecutorType
     let downloadExecutorType: DownloadExecutorType
     let uploadExecutorType: UploadExecutorType
@@ -27,8 +27,8 @@ public struct Configuration {
      *
      * - Parameter baseURL: The base URL used within the client.
      * - Parameter interceptors: A list of interceptors to intercept the request before sending (`RequestInterceptor`) it or intersect the response after receiving it (`ResponseInterceptor`).
-     * - Parameter encoder: The encoder to use to encode the request body data before sending it.
-     * - Parameter decoder: The decoder to use to decode the response body data before returning it.
+     * - Parameter encoder: The standard encoder to use to encode the request body data before sending it.
+     * - Parameter decoder: The standard decoder to use to decode the response body data before returning it.
      * - Parameter requestExecutorType: The request executor type to use to execute the requests.
      * - Parameter downloadExecutorType: The download executor type to use to execute downloads.
      * - Parameter uploadExecutorType: The upload executor type to use to execute uploads
@@ -37,8 +37,8 @@ public struct Configuration {
     public init(
         baseURL: URL,
         interceptors: [Interceptor],
-        encoder: JSONEncoder,
-        decoder: JSONDecoder,
+        encoder: Encoder = JSONEncoder(),
+        decoder: Decoder = JSONDecoder(),
         requestExecutorType: RequestExecutorType = .async,
         downloadExecutorType: DownloadExecutorType = .default,
         uploadExecutorType: UploadExecutorType = .default,

--- a/Sources/Jetworking/Client/Endpoint/Endpoint.swift
+++ b/Sources/Jetworking/Client/Endpoint/Endpoint.swift
@@ -3,6 +3,8 @@ import Foundation
 public struct Endpoint<ResponseType> {
     var pathComponents: [String]
     var queryParameters: [String: String?] = [:]
+    var encoder: Encoder?
+    var decoder: Decoder?
 
     /**
      * Initialises an endpoint with the given path component.
@@ -91,5 +93,33 @@ public struct Endpoint<ResponseType> {
      */
     public func addPathComponent(_ pathComponent: String) -> Endpoint<ResponseType> {
         return addPathComponents([pathComponent])
+    }
+
+    /**
+     * Changes the standard encoder this endpoint. The `Client` will use this encoder instead ot the encoder in the `Configuration`
+     *
+     * - parameter encoder: The encoder to use by the client for this endpoint.
+     *
+     * - Returns:
+     * A new endpoint instance with the changed encoder.
+     */
+    public func overrideStandardEncoderWith(_ encoder: Encoder) -> Endpoint {
+        var endpoint = self
+        endpoint.encoder = encoder
+        return endpoint
+    }
+
+    /**
+     * Changes the standard decoder for this endpoint. The `Client` will use this decoder instead ot the decoder in the `Configuration`
+     *
+     * - parameter decoder: The decoder to use by the client for this endpoint.
+     *
+     * - Returns:
+     * A new endpoint instance with the changed decoder.
+     */
+    public func overrideStandardDecoderWith(_ decoder: Decoder) -> Endpoint {
+        var endpoint = self
+        endpoint.decoder = decoder
+        return endpoint
     }
 }

--- a/Sources/Jetworking/Client/Endpoint/Endpoint.swift
+++ b/Sources/Jetworking/Client/Endpoint/Endpoint.swift
@@ -117,7 +117,7 @@ public struct Endpoint<ResponseType> {
      * - Returns:
      * A new endpoint instance with the changed decoder.
      */
-    public func overrideStandardDecoderWith(_ decoder: Decoder) -> Endpoint {
+    public func withCustomDecoder(_ decoder: Decoder) -> Endpoint {
         var endpoint = self
         endpoint.decoder = decoder
         return endpoint

--- a/Sources/Jetworking/Client/Endpoint/Endpoint.swift
+++ b/Sources/Jetworking/Client/Endpoint/Endpoint.swift
@@ -103,7 +103,7 @@ public struct Endpoint<ResponseType> {
      * - Returns:
      * A new endpoint instance with the changed encoder.
      */
-    public func overrideStandardEncoderWith(_ encoder: Encoder) -> Endpoint {
+    public func withCustomEncoder(_ encoder: Encoder) -> Endpoint {
         var endpoint = self
         endpoint.encoder = encoder
         return endpoint

--- a/Sources/Jetworking/Client/ResponseHandler.swift
+++ b/Sources/Jetworking/Client/ResponseHandler.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+enum ResponseHandler {
+    typealias WrappedCompletion<ResponseType> = (HTTPURLResponse, Data?, Decoder, @escaping Client.RequestCompletion<ResponseType>) -> () -> Void
+    enum CompletionWrapper {
+        static func void<ResponseType>(
+            currentURLResponse: HTTPURLResponse,
+            data: Data?,
+            decoder: Decoder,
+            completion: @escaping Client.RequestCompletion<ResponseType>)
+        -> () -> Void
+        {
+            guard ResponseType.self is Void.Type else {
+                return { completion(currentURLResponse, .failure(APIError.unexpectedError)) }
+            }
+
+            return { completion(currentURLResponse, .success(() as! ResponseType)) }
+        }
+
+
+        static func decodable<ResponseType: Decodable>(
+            currentURLResponse: HTTPURLResponse,
+            data: Data?,
+            decoder: Decoder,
+            completion: @escaping Client.RequestCompletion<ResponseType>)
+        -> () -> Void
+        {
+            guard let data = data, let decodedData = try? decoder.decode(ResponseType.self, from: data) else {
+                return { (completion(currentURLResponse, .failure(APIError.decodingError))) }
+            }
+            // Evaluate Header fields --> urlResponse.allHeaderFields
+
+            return { (completion(currentURLResponse, .success(decodedData))) }
+        }
+    }
+
+    // TODO: Improve this function (Error handling, evaluation of header fields, status code evalutation, ...)
+    static func evaluate<ResponseType>(
+        data: Data?,
+        urlResponse: URLResponse?,
+        error: Error?,
+        endpoint: Endpoint<ResponseType>? = nil,
+        configuration: Configuration,
+        completionWrapper: @escaping WrappedCompletion<ResponseType>,
+        completion: @escaping Client.RequestCompletion<ResponseType>
+    ) {
+        let interceptedResponse = configuration.responseInterceptors.reduce(urlResponse) { response, component in
+            return component.intercept(data: data, response: response, error: error)
+        }
+
+        guard let currentURLResponse = interceptedResponse as? HTTPURLResponse else {
+            return self.configuration(configuration, enqueue: completion(nil, .failure(error ?? APIError.responseMissing)))
+        }
+
+        if let error = error { return self.configuration(configuration, enqueue: completion(currentURLResponse, .failure(error))) }
+
+        switch HTTPStatusCodeType(statusCode: currentURLResponse.statusCode) {
+        case .successful:
+            let decoder = endpoint?.decoder ?? configuration.decoder
+            self.configuration(configuration, enqueue: completionWrapper(currentURLResponse, data, decoder, completion)())
+
+        case .clientError, .serverError:
+            guard let error = error else { return completion(currentURLResponse, .failure(APIError.unexpectedError)) }
+
+            self.configuration(configuration, enqueue: completion(currentURLResponse, .failure(error)))
+
+        default:
+            return
+        }
+    }
+
+    private static func configuration(_ configuration: Configuration, enqueue completion: @escaping @autoclosure () -> Void) {
+        configuration.responseQueue.async {
+            completion()
+        }
+    }
+}

--- a/Sources/Jetworking/Client/ResponseHandler.swift
+++ b/Sources/Jetworking/Client/ResponseHandler.swift
@@ -1,31 +1,35 @@
 import Foundation
 
-enum ResponseHandler {
+final class ResponseHandler {
     private typealias WrappedCompletion<ResponseType> = (HTTPURLResponse, Data?, Error?, Decoder, @escaping Client.RequestCompletion<ResponseType>) -> () -> Void
 
-    static func handleVoidResponse<ResponseType>(
+    private let configuration: Configuration
+
+    init(configuration: Configuration) {
+        self.configuration = configuration
+    }
+
+    func handleVoidResponse<ResponseType>(
         data: Data?,
         urlResponse: URLResponse?,
         error: Error?,
         endpoint: Endpoint<ResponseType>? = nil,
-        configuration: Configuration,
         completion: @escaping Client.RequestCompletion<ResponseType>
     ) {
-        evaluate(data: data, urlResponse: urlResponse, error: error, endpoint: endpoint, configuration: configuration, completionWrapper: Self.makeVoidCompletionWrapper, completion: completion)
+        evaluate(data: data, urlResponse: urlResponse, error: error, endpoint: endpoint, completionWrapper: makeVoidCompletionWrapper, completion: completion)
     }
 
-    static func handleDecodableResponse<ResponseType: Decodable>(
-    data: Data?,
-    urlResponse: URLResponse?,
-    error: Error?,
-    endpoint: Endpoint<ResponseType>? = nil,
-    configuration: Configuration,
-    completion: @escaping Client.RequestCompletion<ResponseType>
+    func handleDecodableResponse<ResponseType: Decodable>(
+        data: Data?,
+        urlResponse: URLResponse?,
+        error: Error?,
+        endpoint: Endpoint<ResponseType>? = nil,
+        completion: @escaping Client.RequestCompletion<ResponseType>
     ) {
-        evaluate(data: data, urlResponse: urlResponse, error: error, endpoint: endpoint, configuration: configuration, completionWrapper: Self.makeDecodableCompletionWrapper, completion: completion)
+        evaluate(data: data, urlResponse: urlResponse, error: error, endpoint: endpoint, completionWrapper: makeDecodableCompletionWrapper, completion: completion)
     }
 
-    private static func makeVoidCompletionWrapper<ResponseType>(
+    private func makeVoidCompletionWrapper<ResponseType>(
         currentURLResponse: HTTPURLResponse?,
         data: Data?,
         error: Error?,
@@ -40,7 +44,7 @@ enum ResponseHandler {
         return { completion(currentURLResponse, .success(() as! ResponseType)) }
     }
 
-    private static func makeDecodableCompletionWrapper<ResponseType: Decodable>(
+    private func makeDecodableCompletionWrapper<ResponseType: Decodable>(
         currentURLResponse: HTTPURLResponse?,
         data: Data?,
         error: Error?,
@@ -60,12 +64,11 @@ enum ResponseHandler {
     }
 
     // TODO: Improve this function (Error handling, evaluation of header fields, status code evalutation, ...)
-    private static func evaluate<ResponseType>(
+    private func evaluate<ResponseType>(
         data: Data?,
         urlResponse: URLResponse?,
         error: Error?,
         endpoint: Endpoint<ResponseType>? = nil,
-        configuration: Configuration,
         completionWrapper: @escaping WrappedCompletion<ResponseType>,
         completion: @escaping Client.RequestCompletion<ResponseType>
     ) {
@@ -74,27 +77,27 @@ enum ResponseHandler {
         }
 
         guard let currentURLResponse = interceptedResponse as? HTTPURLResponse else {
-            return self.enqueue(completion(nil, .failure(error ?? APIError.responseMissing)), inDispatchQueue: configuration.responseQueue)
+            return enqueue(completion(nil, .failure(error ?? APIError.responseMissing)), inDispatchQueue: configuration.responseQueue)
         }
 
-        if let error = error { return self.enqueue(completion(currentURLResponse, .failure(error)), inDispatchQueue: configuration.responseQueue) }
+        if let error = error { return enqueue(completion(currentURLResponse, .failure(error)), inDispatchQueue: configuration.responseQueue) }
 
         switch HTTPStatusCodeType(statusCode: currentURLResponse.statusCode) {
         case .successful:
             let decoder = endpoint?.decoder ?? configuration.decoder
-            self.enqueue(completionWrapper(currentURLResponse, data, nil, decoder, completion)(), inDispatchQueue: configuration.responseQueue)
+            enqueue(completionWrapper(currentURLResponse, data, nil, decoder, completion)(), inDispatchQueue: configuration.responseQueue)
 
         case .clientError, .serverError:
             guard let error = error else { return completion(currentURLResponse, .failure(APIError.unexpectedError)) }
 
-            self.enqueue(completion(currentURLResponse, .failure(error)), inDispatchQueue: configuration.responseQueue)
+            enqueue(completion(currentURLResponse, .failure(error)), inDispatchQueue: configuration.responseQueue)
 
         default:
             return
         }
     }
 
-    private static func enqueue(_ completion: @escaping @autoclosure () -> Void, inDispatchQueue queue: DispatchQueue) {
+    private func enqueue(_ completion: @escaping @autoclosure () -> Void, inDispatchQueue queue: DispatchQueue) {
         queue.async {
             completion()
         }

--- a/Sources/Jetworking/Extensions/JSONDecoder+Extension.swift
+++ b/Sources/Jetworking/Extensions/JSONDecoder+Extension.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+extension JSONDecoder: Decoder {}

--- a/Sources/Jetworking/Extensions/JSONEncoder+Extension.swift
+++ b/Sources/Jetworking/Extensions/JSONEncoder+Extension.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+extension JSONEncoder: Encoder {}

--- a/Sources/Jetworking/Utility/SessionCache.swift
+++ b/Sources/Jetworking/Utility/SessionCache.swift
@@ -3,8 +3,8 @@ import Foundation
 @dynamicMemberLookup
 public final class SessionCache {
     private let cache: URLCache
-    private let encoder: JSONEncoder
-    private let decoder: JSONDecoder
+    private let encoder: Encoder
+    private let decoder: Decoder
     private let interceptors: [SessionCacheInterceptor]
 
     // MARK: - Initializers
@@ -30,7 +30,7 @@ public final class SessionCache {
     ///   - encoder: An encoder for `json` format.
     ///   - decoder: A decoder for `json` format.
     ///   - interceptors: A collection of `SessionCacheInterceptor` instances.
-    init(cache: URLCache, encoder: JSONEncoder, decoder: JSONDecoder, interceptors: [SessionCacheInterceptor]) {
+    init(cache: URLCache, encoder: Encoder, decoder: Decoder, interceptors: [SessionCacheInterceptor]) {
         self.cache = cache
         self.encoder = encoder
         self.decoder = decoder

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -320,7 +320,7 @@ final class ClientTests: XCTestCase {
 
     func testFileDownloadFromSessionCache() {
         let cache = URLCache(memoryCapacity: 10 * 1_024 * 1_024, diskCapacity: .zero, diskPath: nil)
-        let configuration = extendClientConfiguration(makeDefaultClientConfiguration(), with: cache)
+        let configuration = Configurations.extendClientConfiguration(Configurations.default(), with: cache)
         let client = Client(configuration: configuration)
 
         let firstExpectation = XCTestExpectation(description: "Wait for remote download")
@@ -360,7 +360,7 @@ final class ClientTests: XCTestCase {
 
     func testForcedFileDownload() {
         let cache = URLCache(memoryCapacity: 10 * 1_024 * 1_024, diskCapacity: .zero, diskPath: nil)
-        let configuration = extendClientConfiguration(makeDefaultClientConfiguration(), with: cache)
+        let configuration = Configurations.extendClientConfiguration(Configurations.default(), with: cache)
         let client = Client(configuration: configuration)
 
         let firstExpectation = XCTestExpectation(description: "Wait for remote download")

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -475,7 +475,7 @@ final class ClientTests: XCTestCase {
         }
 
         let body: MockBody = .init(foo1: "bar1", foo2: "bar2")
-        client.post(endpoint: Endpoints.post.overrideStandardEncoderWith(testableEncoder), body: body) { response, result in
+        client.post(endpoint: Endpoints.post.withCustomEncoder(testableEncoder), body: body) { response, result in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
             switch result {
             case .failure:
@@ -494,7 +494,7 @@ final class ClientTests: XCTestCase {
             putEncodingCalledExpectation.fulfill()
         }
 
-        client.put(endpoint: Endpoints.put.overrideStandardEncoderWith(testableEncoder), body: body) { response, result in
+        client.put(endpoint: Endpoints.put.withCustomEncoder(testableEncoder), body: body) { response, result in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
             switch result {
             case .failure:
@@ -513,7 +513,7 @@ final class ClientTests: XCTestCase {
             patchEncodingCalledExpectation.fulfill()
         }
 
-        client.patch(endpoint: Endpoints.patch.overrideStandardEncoderWith(testableEncoder), body: body) { response, result in
+        client.patch(endpoint: Endpoints.patch.withCustomEncoder(testableEncoder), body: body) { response, result in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
             switch result {
             case .failure:

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -355,7 +355,7 @@ final class ClientTests: XCTestCase {
             firstExpectation.fulfill()
         }
 
-        wait(for: [firstExpectation, secondExpectation], timeout: 20.0)
+        wait(for: [firstExpectation, secondExpectation], timeout: 60.0)
     }
 
     func testForcedFileDownload() {
@@ -392,7 +392,7 @@ final class ClientTests: XCTestCase {
             firstExpectation.fulfill()
         }
 
-        wait(for: [firstExpectation, secondExpectation], timeout: 20.0)
+        wait(for: [firstExpectation, secondExpectation], timeout: 60.0)
     }
 
     func testUploadFile() {

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -551,7 +551,7 @@ final class ClientTests: XCTestCase {
             getDecoderCalledExpectation.fulfill()
         }
 
-        client.get(endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue").overrideStandardDecoderWith(testableDecoder)) { response, result in
+        client.get(endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue").withCustomDecoder(testableDecoder)) { response, result in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
 
             switch result {
@@ -585,7 +585,7 @@ final class ClientTests: XCTestCase {
             postDecodingCalledExpectation.fulfill()
         }
 
-        client.post(endpoint: Endpoints.post.overrideStandardDecoderWith(testableDecoder), body: body) { response, result in
+        client.post(endpoint: Endpoints.post.withCustomDecoder(testableDecoder), body: body) { response, result in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
             switch result {
             case .failure:
@@ -617,7 +617,7 @@ final class ClientTests: XCTestCase {
             putDecodingCalledExpectation.fulfill()
         }
 
-        client.put(endpoint: Endpoints.put.overrideStandardDecoderWith(testableDecoder), body: body) { response, result in
+        client.put(endpoint: Endpoints.put.withCustomDecoder(testableDecoder), body: body) { response, result in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
             switch result {
             case .failure:
@@ -649,7 +649,7 @@ final class ClientTests: XCTestCase {
             patchDecodingCalledExpectation.fulfill()
         }
 
-        client.patch(endpoint: Endpoints.patch.overrideStandardDecoderWith(testableDecoder), body: body) { response, result in
+        client.patch(endpoint: Endpoints.patch.withCustomDecoder(testableDecoder), body: body) { response, result in
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
             switch result {
             case .failure:

--- a/Tests/JetworkingTests/ClientTests/CustomDecoderTests.swift
+++ b/Tests/JetworkingTests/ClientTests/CustomDecoderTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+import Foundation
+@testable import Jetworking
+
+final class CustomDecoderTests: XCTestCase {
+    func testCustomDecoderForGet() {
+        let testableDecoder = TestableDecoder()
+        let client = Client(configuration: Configurations.default(.sync)) { session in
+            session.configuration.timeoutIntervalForRequest = 30
+        }
+
+        let getDecoderCalledExpectation = expectation(description: "Decoder method called for get")
+        let waitForGetExpectation = expectation(description: "Wait for get")
+
+        testableDecoder.decodeCalled = {
+            getDecoderCalledExpectation.fulfill()
+        }
+
+        client.get(endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue").withCustomDecoder(testableDecoder)) { response, result in
+            dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+
+            switch result {
+            case .failure:
+                break
+
+            case let .success(resultData):
+                print(resultData)
+            }
+
+            XCTAssertNotNil(response)
+            XCTAssertEqual(response?.statusCode, 200)
+            waitForGetExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
+
+    func testCustomDecoderForPost() {
+        let testableDecoder = TestableDecoder()
+        let client = Client(configuration: Configurations.default(.sync)) { session in
+            session.configuration.timeoutIntervalForRequest = 30
+        }
+
+        let postDecodingCalledExpectation = expectation(description: "Decoder method called for post")
+        let waitForPostExpectation = expectation(description: "Wait for post")
+
+        let body: MockBody = .init(foo1: "bar1", foo2: "bar2")
+
+        testableDecoder.decodeCalled = {
+            postDecodingCalledExpectation.fulfill()
+        }
+
+        client.post(endpoint: Endpoints.post.withCustomDecoder(testableDecoder), body: body) { response, result in
+            dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+            switch result {
+            case .failure:
+                break
+
+            case let .success(resultData):
+                print(resultData)
+            }
+
+            XCTAssertNotNil(response)
+            XCTAssertEqual(response?.statusCode, 200)
+            waitForPostExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
+
+    func testCustomDecoderForPut() {
+        let testableDecoder = TestableDecoder()
+        let client = Client(configuration: Configurations.default(.sync)) { session in
+            session.configuration.timeoutIntervalForRequest = 30
+        }
+
+        let putDecodingCalledExpectation = expectation(description: "Decoder method called for put")
+        let waitForPutExpectation = expectation(description: "Wait for put")
+
+        let body: MockBody = .init(foo1: "bar1", foo2: "bar2")
+        testableDecoder.decodeCalled = {
+            putDecodingCalledExpectation.fulfill()
+        }
+
+        client.put(endpoint: Endpoints.put.withCustomDecoder(testableDecoder), body: body) { response, result in
+            dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+            switch result {
+            case .failure:
+                break
+
+            case let .success(resultData):
+                print(resultData)
+            }
+
+            XCTAssertNotNil(response)
+            XCTAssertEqual(response?.statusCode, 200)
+            waitForPutExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
+
+    func testCustomDecoderForPatch() {
+        let testableDecoder = TestableDecoder()
+        let client = Client(configuration: Configurations.default(.sync)) { session in
+            session.configuration.timeoutIntervalForRequest = 30
+        }
+
+        let patchDecodingCalledExpectation = expectation(description: "Decoder method called for patch")
+        let waitForPatchExpectation = expectation(description: "Wait for patch")
+
+        let body: MockBody = .init(foo1: "bar1", foo2: "bar2")
+        testableDecoder.decodeCalled = {
+            patchDecodingCalledExpectation.fulfill()
+        }
+
+        client.patch(endpoint: Endpoints.patch.withCustomDecoder(testableDecoder), body: body) { response, result in
+            dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+            switch result {
+            case .failure:
+                break
+
+            case let .success(resultData):
+                print(resultData)
+            }
+
+            XCTAssertNotNil(response)
+            XCTAssertEqual(response?.statusCode, 200)
+            waitForPatchExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
+}

--- a/Tests/JetworkingTests/ClientTests/TestableDecoder.swift
+++ b/Tests/JetworkingTests/ClientTests/TestableDecoder.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Jetworking
+
+class TestableDecoder: Decoder {
+    /**
+     * This callback is invoked when the decode method is called.
+     */
+    var decodeCalled: (() -> Void)?
+
+    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable {
+        decodeCalled?()
+        return try JSONDecoder().decode(type, from: data)
+    }
+}

--- a/Tests/JetworkingTests/ClientTests/TestableEncoder.swift
+++ b/Tests/JetworkingTests/ClientTests/TestableEncoder.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Jetworking
+
+class TestableEncoder: Encoder {
+    /**
+     * This callback is invoked when the encode method is called.
+     */
+    var encodeCalled: (() -> Void)?
+
+    func encode<T>(_ value: T) throws -> Data where T : Encodable {
+        encodeCalled?()
+        return try JSONEncoder().encode(value)
+    }
+}

--- a/Tests/JetworkingTests/MockData/Configurations.swift
+++ b/Tests/JetworkingTests/MockData/Configurations.swift
@@ -1,0 +1,18 @@
+import Foundation
+@testable import Jetworking
+
+enum Configurations {
+    static func `default`(_ requestExecutorType: RequestExecutorType = .async) -> Configuration {
+        return .init(
+            baseURL: URL(string: "https://postman-echo.com")!,
+            interceptors: [
+                AuthenticationRequestInterceptor(
+                    authenticationMethod: .basicAuthentication(username: "username", password: "password")
+                ),
+                HeaderFieldsRequestInterceptor(headerFields: HeaderFields.additional),
+                LoggingInterceptor()
+            ],
+            requestExecutorType: requestExecutorType
+        )
+    }
+}

--- a/Tests/JetworkingTests/MockData/Configurations.swift
+++ b/Tests/JetworkingTests/MockData/Configurations.swift
@@ -15,4 +15,15 @@ enum Configurations {
             requestExecutorType: requestExecutorType
         )
     }
+
+    static func extendClientConfiguration(_ configuration: Configuration, with cache: URLCache) -> Configuration {
+        return .init(
+            baseURL: configuration.baseURL,
+            interceptors: configuration.interceptors + [DefaultSessionCacheIntercepter()],
+            encoder: configuration.encoder,
+            decoder: configuration.decoder,
+            requestExecutorType: configuration.requestExecutorType,
+            cache: cache
+        )
+    }
 }

--- a/Tests/JetworkingTests/MockData/HeaderFields.swift
+++ b/Tests/JetworkingTests/MockData/HeaderFields.swift
@@ -1,0 +1,9 @@
+import Foundation
+@testable import Jetworking
+
+enum HeaderFields {
+    static let additional: [String: String] = [
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+    ]
+}

--- a/Tests/JetworkingTests/UtilityTests/SessionCacheTests.swift
+++ b/Tests/JetworkingTests/UtilityTests/SessionCacheTests.swift
@@ -126,8 +126,8 @@ extension SessionCacheTests {
                 diskCapacity: .zero,
                 diskPath: nil
             ),
-            encoder: .init(),
-            decoder: .init(),
+            encoder: JSONEncoder(),
+            decoder: JSONDecoder(),
             interceptors: [
                 DefaultSessionCacheIntercepter(storagePolicy: .allowedInMemoryOnly)
             ]


### PR DESCRIPTION
Implements Decoder/Encoder protocols that can be used to change the decoder/encoder properties in `Configuration`. These decoder/encoder can be overridden for particular endpoints by the `overrideStandardDecoderWith(_ decoder: Decoder)` method in `Endpoint`.

Fixes a bug where a method overload didn't work as expected: Because of this all responses from the backend weren't decoded at all.