### PR TITLE
Unify name of executers

### DIFF
--- a/Sources/Jetworking/Client/Configuration/Configuration.swift
+++ b/Sources/Jetworking/Client/Configuration/Configuration.swift
@@ -6,9 +6,9 @@ public struct Configuration {
     let interceptors: [Interceptor]
     let encoder: Encoder
     let decoder: Decoder
-    let requestExecutorType: RequestExecutorType
-    let downloadExecutorType: DownloadExecutorType
-    let uploadExecutorType: UploadExecutorType
+    let requestExecuterType: RequestExecuterType
+    let downloadExecuterType: DownloadExecuterType
+    let uploadExecuterType: UploadExecuterType
     let responseQueue: DispatchQueue
     let cache: URLCache
 
@@ -29,9 +29,9 @@ public struct Configuration {
      * - Parameter interceptors: A list of interceptors to intercept the request before sending (`RequestInterceptor`) it or intersect the response after receiving it (`ResponseInterceptor`).
      * - Parameter encoder: The standard encoder to use to encode the request body data before sending it.
      * - Parameter decoder: The standard decoder to use to decode the response body data before returning it.
-     * - Parameter requestExecutorType: The request executor type to use to execute the requests.
-     * - Parameter downloadExecutorType: The download executor type to use to execute downloads.
-     * - Parameter uploadExecutorType: The upload executor type to use to execute uploads
+     * - Parameter requestExecuterType: The request executer type to use to execute the requests.
+     * - Parameter downloadExecuterType: The download executer type to use to execute downloads.
+     * - Parameter uploadExecuterType: The upload executer type to use to execute uploads
      * - Parameter cache: A cache object that realizes caching mechanism. IMPORTANT: At least one instance of `SessionCacheInterceptor` is required.
      */
     public init(
@@ -39,9 +39,9 @@ public struct Configuration {
         interceptors: [Interceptor],
         encoder: Encoder = JSONEncoder(),
         decoder: Decoder = JSONDecoder(),
-        requestExecutorType: RequestExecutorType = .async,
-        downloadExecutorType: DownloadExecutorType = .default,
-        uploadExecutorType: UploadExecutorType = .default,
+        requestExecuterType: RequestExecuterType = .async,
+        downloadExecuterType: DownloadExecuterType = .default,
+        uploadExecuterType: UploadExecuterType = .default,
         responseQueue: DispatchQueue = .main,
         cache: URLCache = .shared
     ) {
@@ -49,9 +49,9 @@ public struct Configuration {
         self.interceptors = interceptors
         self.encoder = encoder
         self.decoder = decoder
-        self.requestExecutorType = requestExecutorType
-        self.downloadExecutorType = downloadExecutorType
-        self.uploadExecutorType = uploadExecutorType
+        self.requestExecuterType = requestExecuterType
+        self.downloadExecuterType = downloadExecuterType
+        self.uploadExecuterType = uploadExecuterType
         self.responseQueue = responseQueue
         self.cache = cache
     }

--- a/Sources/Jetworking/Client/Executor/DownloadExecutor/Background/BackgroundDownloadExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/DownloadExecutor/Background/BackgroundDownloadExecuter.swift
@@ -5,14 +5,14 @@ import Foundation
  *  A background download may be useful when having a lot of data to download and not wanting the user to have to wait for a long time.
  *  It may also be useful to download files in the background when the app does not directly need to use it.
  *  For example when having a music playlist the user wants to download to be able to use it on the go without wasting mobile data.
- *  As this download might take some time and one does not want the user to always have the app in foreground, the background download executor might be a good choice.
+ *  As this download might take some time and one does not want the user to always have the app in foreground, the background download executer might be a good choice.
  *  Furthermore for video downloads, when wanting to be able to watch them on the go when internet might not be availeble, it might be suitable.
  *
- * Nevertheless this background download executor is still a work in progress approach and needs some optimisations as well as some adjustments to the programmers app itself
+ * Nevertheless this background download executer is still a work in progress approach and needs some optimisations as well as some adjustments to the programmers app itself
  * which need to be investigated further.
  */
-final class BackgroundDownloadExecutor: NSObject, DownloadExecutor {
-    var delegate: DownloadExecutorDelegate?
+final class BackgroundDownloadExecuter: NSObject, DownloadExecuter {
+    var delegate: DownloadExecuterDelegate?
     var sessionConfiguration: URLSessionConfiguration
 
     private var backgroundIdentifier: String
@@ -27,9 +27,9 @@ final class BackgroundDownloadExecutor: NSObject, DownloadExecutor {
         return session
     }()
 
-    init(sessionConfiguration: URLSessionConfiguration, downloadExecutorDelegate: DownloadExecutorDelegate) {
+    init(sessionConfiguration: URLSessionConfiguration, downloadExecuterDelegate: DownloadExecuterDelegate) {
         self.sessionConfiguration = sessionConfiguration
-        self.delegate = downloadExecutorDelegate
+        self.delegate = downloadExecuterDelegate
         self.backgroundIdentifier = "com.jamitlabs.jetworking.background"
         self.isDiscretionary = false
 
@@ -38,11 +38,11 @@ final class BackgroundDownloadExecutor: NSObject, DownloadExecutor {
 
     /**
      * # Summary
-     *  Initialises a download executor to download.
+     *  Initialises a download executer to download.
      *
      * - Parameter sessionConfiguration:
-     *  The session configuration to use within the download executor.
-     * - Parameter downloadExecutorDelegate:
+     *  The session configuration to use within the download executer.
+     * - Parameter downloadExecuterDelegate:
      *  The delegate to send the download updates to.
      * - Parameter backgroundIdentifier:
      *  When having an app extension which also handles download functionality make sure to set different background Identifiers as otherwise problems might occur
@@ -54,12 +54,12 @@ final class BackgroundDownloadExecutor: NSObject, DownloadExecutor {
      */
     init(
         sessionConfiguration: URLSessionConfiguration,
-        downloadExecutorDelegate: DownloadExecutorDelegate,
+        downloadExecuterDelegate: DownloadExecuterDelegate,
         backgroundIdentifier: String = "com.jamitlabs.jetworking.background",
         isDiscretionary: Bool = false
     ) {
         self.sessionConfiguration = sessionConfiguration
-        self.delegate = downloadExecutorDelegate
+        self.delegate = downloadExecuterDelegate
         self.backgroundIdentifier = backgroundIdentifier
         self.isDiscretionary = isDiscretionary
 
@@ -83,18 +83,18 @@ final class BackgroundDownloadExecutor: NSObject, DownloadExecutor {
     }
 }
 
-extension BackgroundDownloadExecutor: URLSessionDownloadDelegate {
+extension BackgroundDownloadExecuter: URLSessionDownloadDelegate {
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
-        delegate?.downloadExecutor(downloadTask, didWriteData: bytesWritten, totalBytesWritten: totalBytesWritten, totalBytesExpectedToWrite: totalBytesExpectedToWrite)
+        delegate?.downloadExecuter(downloadTask, didWriteData: bytesWritten, totalBytesWritten: totalBytesWritten, totalBytesExpectedToWrite: totalBytesExpectedToWrite)
     }
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
-        delegate?.downloadExecutor(downloadTask, didFinishDownloadingTo: location)
+        delegate?.downloadExecuter(downloadTask, didFinishDownloadingTo: location)
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard let downloadTask = task as? URLSessionDownloadTask else { return }
 
-        delegate?.downloadExecutor(downloadTask, didCompleteWithError: error)
+        delegate?.downloadExecuter(downloadTask, didCompleteWithError: error)
     }
 }

--- a/Sources/Jetworking/Client/Executor/DownloadExecutor/Default/DefaultDownloadExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/DownloadExecutor/Default/DefaultDownloadExecuter.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-final class DefaultDownloadExecutor: NSObject, DownloadExecutor {
-    var delegate: DownloadExecutorDelegate?
+final class DefaultDownloadExecuter: NSObject, DownloadExecuter {
+    var delegate: DownloadExecuterDelegate?
     var sessionConfiguration: URLSessionConfiguration
 
     private lazy var session: URLSession = .init(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
 
-    init(sessionConfiguration: URLSessionConfiguration, downloadExecutorDelegate: DownloadExecutorDelegate) {
+    init(sessionConfiguration: URLSessionConfiguration, downloadExecuterDelegate: DownloadExecuterDelegate) {
         self.sessionConfiguration = sessionConfiguration
-        self.delegate = downloadExecutorDelegate
+        self.delegate = downloadExecuterDelegate
 
         super.init()
     }
@@ -30,18 +30,18 @@ final class DefaultDownloadExecutor: NSObject, DownloadExecutor {
     }
 }
 
-extension DefaultDownloadExecutor: URLSessionDownloadDelegate {
+extension DefaultDownloadExecuter: URLSessionDownloadDelegate {
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
-        delegate?.downloadExecutor(downloadTask, didWriteData: bytesWritten, totalBytesWritten: totalBytesWritten, totalBytesExpectedToWrite: totalBytesExpectedToWrite)
+        delegate?.downloadExecuter(downloadTask, didWriteData: bytesWritten, totalBytesWritten: totalBytesWritten, totalBytesExpectedToWrite: totalBytesExpectedToWrite)
     }
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
-        delegate?.downloadExecutor(downloadTask, didFinishDownloadingTo: location)
+        delegate?.downloadExecuter(downloadTask, didFinishDownloadingTo: location)
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard let downloadTask = task as? URLSessionDownloadTask else { return }
 
-        delegate?.downloadExecutor(downloadTask, didCompleteWithError: error)
+        delegate?.downloadExecuter(downloadTask, didCompleteWithError: error)
     }
 }

--- a/Sources/Jetworking/Client/Executor/DownloadExecutor/Delegate/DownloadExecuterDelegate.swift
+++ b/Sources/Jetworking/Client/Executor/DownloadExecutor/Delegate/DownloadExecuterDelegate.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-// The delegate protocol for the `DownloadExecutor`.
-public protocol DownloadExecutorDelegate: AnyObject {
+// The delegate protocol for the `DownloadExecuter`.
+public protocol DownloadExecuterDelegate: AnyObject {
     /**
      * # Summary
      *  Delegate which gets called when a progress update happens.
@@ -15,7 +15,7 @@ public protocol DownloadExecutorDelegate: AnyObject {
      * - Parameter totalBytesExpectedToWrite:
      *  The total bytes expected to write.
      */
-    func downloadExecutor(_ downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64)
+    func downloadExecuter(_ downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64)
 
     /**
      * # Summary
@@ -26,7 +26,7 @@ public protocol DownloadExecutorDelegate: AnyObject {
      * - Parameter didFinishDownloadingTo:
      *  The location the file was downloaded to.
      */
-    func downloadExecutor(_ downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL)
+    func downloadExecuter(_ downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL)
 
     /**
      * # Summary
@@ -37,5 +37,5 @@ public protocol DownloadExecutorDelegate: AnyObject {
      * - Parameter didCompleteWithError:
      *  The error which was thrown while downloading.
      */
-    func downloadExecutor(_ downloadTask: URLSessionDownloadTask, didCompleteWithError error: Error?)
+    func downloadExecuter(_ downloadTask: URLSessionDownloadTask, didCompleteWithError error: Error?)
 }

--- a/Sources/Jetworking/Client/Executor/DownloadExecutor/DownloadExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/DownloadExecutor/DownloadExecuter.swift
@@ -1,22 +1,22 @@
 import Foundation
 
-/// The protocol a download executor has to conform to to be used to download.
-public protocol DownloadExecutor: AnyObject {
+/// The protocol a download executer has to conform to to be used to download.
+public protocol DownloadExecuter: AnyObject {
     /// The delegate to set to receive updates on downloads.
-    var delegate: DownloadExecutorDelegate? { get }
+    var delegate: DownloadExecuterDelegate? { get }
     /// The session configuration to use to download.
     var sessionConfiguration: URLSessionConfiguration { get }
 
     /**
      * # Summary
-     *  Initialises a download executor to download.
+     *  Initialises a download executer to download.
      *
      * - Parameter sessionConfiguration:
-     *  The session configuration to use within the download executor.
-     * - Parameter downloadExecutorDelegate:
+     *  The session configuration to use within the download executer.
+     * - Parameter downloadExecuterDelegate:
      *  The delegate to send the download updates to.
      */
-    init(sessionConfiguration: URLSessionConfiguration, downloadExecutorDelegate: DownloadExecutorDelegate)
+    init(sessionConfiguration: URLSessionConfiguration, downloadExecuterDelegate: DownloadExecuterDelegate)
 
     /**
      * # Summary

--- a/Sources/Jetworking/Client/Executor/DownloadExecutor/DownloadExecuterType.swift
+++ b/Sources/Jetworking/Client/Executor/DownloadExecutor/DownloadExecuterType.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-/// The download executor currently supported.
+/// The download executer currently supported.
 /// - `default` for an execution using the default session configuration
 /// - `background` for an execution using the background session configuration. ATTENTION: This is still a work in progress approach which is not yet tested with an app and should be used with care.
 /// - `custom` for a custom execution of download requests provided by the caller.
-public enum DownloadExecutorType {
+public enum DownloadExecuterType {
     case `default`
     case background
-    case custom(DownloadExecutor.Type)
+    case custom(DownloadExecuter.Type)
 }

--- a/Sources/Jetworking/Client/Executor/RequestExecuter/AsyncRequestExecuter/AsyncRequestExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/RequestExecuter/AsyncRequestExecuter/AsyncRequestExecuter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class AsyncRequestExecutor: RequestExecutor {
+final class AsyncRequestExecuter: RequestExecuter {
     internal let session: URLSession
 
     init(session: URLSession) {

--- a/Sources/Jetworking/Client/Executor/RequestExecuter/RequestExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/RequestExecuter/RequestExecuter.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-/// The protocol request executors need to conform to to be able to be used to send requests.
-public protocol RequestExecutor {
+/// The protocol request executers need to conform to to be able to be used to send requests.
+public protocol RequestExecuter {
     /// The session the request will be send on
     var session: URLSession { get }
 
     /**
      * # Summary
-     *  The initialiser of the `RequestExecutor`.
+     *  The initialiser of the `RequestExecuter`.
      *
      * - Parameter session:
      *  The session the request will be send on.

--- a/Sources/Jetworking/Client/Executor/RequestExecuter/RequestExecuterType.swift
+++ b/Sources/Jetworking/Client/Executor/RequestExecuter/RequestExecuterType.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-/// The request executor currently supported.
+/// The request executer currently supported.
 /// - `sync` for a synchronous execution of requests.
 /// - `async` for an asynchronous execution of requests.
 /// - `custom` for a custom execution of requests provided by the caller.
-public enum RequestExecutorType {
+public enum RequestExecuterType {
     case async
     case sync
-    case custom(RequestExecutor.Type)
+    case custom(RequestExecuter.Type)
 }

--- a/Sources/Jetworking/Client/Executor/RequestExecuter/SyncRequestExecuter/SyncRequestExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/RequestExecuter/SyncRequestExecuter/SyncRequestExecuter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class SyncRequestExecutor: RequestExecutor {
+final class SyncRequestExecuter: RequestExecuter {
     internal let session: URLSession
 
     private lazy var operationQueue: OperationQueue = {

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/Background/BackgroundUploadExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/Background/BackgroundUploadExecuter.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-final class BackgroundUploadExecutor: NSObject, UploadExecutor {
-    var delegate: UploadExecutorDelegate?
+final class BackgroundUploadExecuter: NSObject, UploadExecuter {
+    var delegate: UploadExecuterDelegate?
     var sessionConfiguration: URLSessionConfiguration
 
     private var backgroundIdentifier: String
@@ -16,9 +16,9 @@ final class BackgroundUploadExecutor: NSObject, UploadExecutor {
         return session
     }()
 
-    init(sessionConfiguration: URLSessionConfiguration, uploadExecutorDelegate: UploadExecutorDelegate) {
+    init(sessionConfiguration: URLSessionConfiguration, uploadExecuterDelegate: UploadExecuterDelegate) {
         self.sessionConfiguration = sessionConfiguration
-        self.delegate = uploadExecutorDelegate
+        self.delegate = uploadExecuterDelegate
         self.backgroundIdentifier = "com.jamitlabs.jetworking.background"
         self.isDiscretionary = false
 
@@ -27,11 +27,11 @@ final class BackgroundUploadExecutor: NSObject, UploadExecutor {
 
     /**
      * # Summary
-     *  Initialises a download executor to download.
+     *  Initialises a download executer to download.
      *
      * - Parameter sessionConfiguration:
-     *  The session configuration to use within the download executor.
-     * - Parameter downloadExecutorDelegate:
+     *  The session configuration to use within the download executer.
+     * - Parameter downloadExecuterDelegate:
      *  The delegate to send the download updates to.
      * - Parameter backgroundIdentifier:
      *  When having an app extension which also handles download functionality make sure to set different background Identifiers as otherwise problems might occur
@@ -43,12 +43,12 @@ final class BackgroundUploadExecutor: NSObject, UploadExecutor {
      */
     init(
         sessionConfiguration: URLSessionConfiguration,
-        uploadExecutorDelegate: UploadExecutorDelegate,
+        uploadExecuterDelegate: UploadExecuterDelegate,
         backgroundIdentifier: String = "com.jamitlabs.jetworking.background",
         isDiscretionary: Bool = false
     ) {
         self.sessionConfiguration = sessionConfiguration
-        self.delegate = uploadExecutorDelegate
+        self.delegate = uploadExecuterDelegate
         self.backgroundIdentifier = backgroundIdentifier
         self.isDiscretionary = isDiscretionary
 
@@ -98,20 +98,20 @@ final class BackgroundUploadExecutor: NSObject, UploadExecutor {
     }
 }
 
-extension BackgroundUploadExecutor: URLSessionTaskDelegate {
+extension BackgroundUploadExecuter: URLSessionTaskDelegate {
     func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
         guard let uploadTask = task as? URLSessionUploadTask else { return }
 
-        delegate?.uploadExecutor(uploadTask, didSendBodyData: bytesSent, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
+        delegate?.uploadExecuter(uploadTask, didSendBodyData: bytesSent, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard let uploadTask = task as? URLSessionUploadTask else { return }
 
         if let error = error {
-            delegate?.uploadExecutor(uploadTask, didCompleteWithError: error)
+            delegate?.uploadExecuter(uploadTask, didCompleteWithError: error)
         } else {
-            delegate?.uploadExecutor(didFinishWith: uploadTask)
+            delegate?.uploadExecuter(didFinishWith: uploadTask)
         }
     }
 }

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/Default/DefaultUploadExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/Default/DefaultUploadExecuter.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-final class DefaultUploadExecutor: NSObject, UploadExecutor {
-    var delegate: UploadExecutorDelegate?
+final class DefaultUploadExecuter: NSObject, UploadExecuter {
+    var delegate: UploadExecuterDelegate?
     var sessionConfiguration: URLSessionConfiguration
 
     private lazy var session: URLSession = .init(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
 
-    init(sessionConfiguration: URLSessionConfiguration, uploadExecutorDelegate: UploadExecutorDelegate) {
+    init(sessionConfiguration: URLSessionConfiguration, uploadExecuterDelegate: UploadExecuterDelegate) {
         self.sessionConfiguration = sessionConfiguration
-        self.delegate = uploadExecutorDelegate
+        self.delegate = uploadExecuterDelegate
 
         super.init()
     }
@@ -50,20 +50,20 @@ final class DefaultUploadExecutor: NSObject, UploadExecutor {
     }
 }
 
-extension DefaultUploadExecutor: URLSessionTaskDelegate {
+extension DefaultUploadExecuter: URLSessionTaskDelegate {
     func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
         guard let uploadTask = task as? URLSessionUploadTask else { return }
 
-        delegate?.uploadExecutor(uploadTask, didSendBodyData: bytesSent, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
+        delegate?.uploadExecuter(uploadTask, didSendBodyData: bytesSent, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard let uploadTask = task as? URLSessionUploadTask else { return }
 
         if let error = error {
-            delegate?.uploadExecutor(uploadTask, didCompleteWithError: error)
+            delegate?.uploadExecuter(uploadTask, didCompleteWithError: error)
         } else {
-            delegate?.uploadExecutor(didFinishWith: uploadTask)
+            delegate?.uploadExecuter(didFinishWith: uploadTask)
         }
     }
 }

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/Delegate/UploadExecuterDelegate.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/Delegate/UploadExecuterDelegate.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-// The delegate protocol for the `UploadExecutor`.
-public protocol UploadExecutorDelegate: AnyObject {
+// The delegate protocol for the `UploadExecuter`.
+public protocol UploadExecuterDelegate: AnyObject {
     /**
      * # Summary
      *  Delegate which gets called when a progress update happens.
@@ -15,7 +15,7 @@ public protocol UploadExecutorDelegate: AnyObject {
      * - Parameter totalBytesExpectedToSend:
      *  The total bytes expected to send.
      */
-    func uploadExecutor(_ uploadTask: URLSessionUploadTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64)
+    func uploadExecuter(_ uploadTask: URLSessionUploadTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64)
 
     /**
      * # Summary
@@ -24,7 +24,7 @@ public protocol UploadExecutorDelegate: AnyObject {
      * - Parameter downloadTask:
      *  The upload task the upload is executed on..
      */
-    func uploadExecutor(didFinishWith uploadTask: URLSessionUploadTask)
+    func uploadExecuter(didFinishWith uploadTask: URLSessionUploadTask)
 
     /**
      * # Summary
@@ -35,5 +35,5 @@ public protocol UploadExecutorDelegate: AnyObject {
      * - Parameter didCompleteWithError:
      *  The error which was thrown while uploading.
      */
-    func uploadExecutor(_ uploadTask: URLSessionUploadTask, didCompleteWithError error: Error?)
+    func uploadExecuter(_ uploadTask: URLSessionUploadTask, didCompleteWithError error: Error?)
 }

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/UploadExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/UploadExecuter.swift
@@ -1,22 +1,22 @@
 import Foundation
 
-/// The protocol an upload executor has to conform to to be used to upload.
-public protocol UploadExecutor: AnyObject {
+/// The protocol an upload executer has to conform to to be used to upload.
+public protocol UploadExecuter: AnyObject {
     /// The delegate to set to receive updates on uploads.
-    var delegate: UploadExecutorDelegate? { get }
+    var delegate: UploadExecuterDelegate? { get }
     /// The session configuration to use to upload.
     var sessionConfiguration: URLSessionConfiguration { get }
 
     /**
      * # Summary
-     *  Initialises an upload executor to upload.
+     *  Initialises an upload executer to upload.
      *
      * - Parameter sessionConfiguration:
-     *  The session configuration to use within the upload executor.
-     * - Parameter downloadExecutorDelegate:
+     *  The session configuration to use within the upload executer.
+     * - Parameter downloadExecuterDelegate:
      *  The delegate to send the upload updates to.
      */
-    init(sessionConfiguration: URLSessionConfiguration, uploadExecutorDelegate: UploadExecutorDelegate)
+    init(sessionConfiguration: URLSessionConfiguration, uploadExecuterDelegate: UploadExecuterDelegate)
 
     /**
      * # Summary

--- a/Sources/Jetworking/Client/Executor/UploadExecutor/UploadExecuterType.swift
+++ b/Sources/Jetworking/Client/Executor/UploadExecutor/UploadExecuterType.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-/// The upload executor currently supported.
+/// The upload executer currently supported.
 /// - `default` for an execution using the default session configuration
 /// - `background` for an execution using the background session configuration. ATTENTION: This is still a work in progress approach which is not yet tested with an app and should be used with care.
 /// - `custom` for a custom execution of upload requests provided by the caller.
-public enum UploadExecutorType {
+public enum UploadExecuterType {
     case `default`
     case background
-    case custom(UploadExecutor.Type)
+    case custom(UploadExecuter.Type)
 }

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -210,7 +210,7 @@ final class ClientTests: XCTestCase {
                 HeaderFieldsRequestInterceptor(headerFields: HeaderFields.additional),
                 LoggingInterceptor()
             ],
-            requestExecutorType: .sync
+            requestExecuterType: .sync
         ))
 
         let firstExpectation = expectation(description: "Wait for first get")
@@ -244,7 +244,7 @@ final class ClientTests: XCTestCase {
         XCTAssertTrue(result == .completed)
     }
 
-    func testIncorrectOrderDueToAsyncRequestExecutor() {
+    func testIncorrectOrderDueToAsyncRequestExecuter() {
         let client = Client(configuration: Configurations.default())
 
         let firstExpectation = expectation(description: "Wait for first get")

--- a/Tests/JetworkingTests/MockData/Configurations.swift
+++ b/Tests/JetworkingTests/MockData/Configurations.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import Jetworking
 
 enum Configurations {
-    static func `default`(_ requestExecutorType: RequestExecutorType = .async) -> Configuration {
+    static func `default`(_ requestExecuterType: RequestExecuterType = .async) -> Configuration {
         return .init(
             baseURL: URL(string: "https://postman-echo.com")!,
             interceptors: [
@@ -12,7 +12,7 @@ enum Configurations {
                 HeaderFieldsRequestInterceptor(headerFields: HeaderFields.additional),
                 LoggingInterceptor()
             ],
-            requestExecutorType: requestExecutorType
+            requestExecuterType: requestExecuterType
         )
     }
 
@@ -22,7 +22,7 @@ enum Configurations {
             interceptors: configuration.interceptors + [DefaultSessionCacheIntercepter()],
             encoder: configuration.encoder,
             decoder: configuration.decoder,
-            requestExecutorType: configuration.requestExecutorType,
+            requestExecuterType: configuration.requestExecuterType,
             cache: cache
         )
     }


### PR DESCRIPTION
# Description
This PR unifies the usage of the name `executer` and removes the usage of `executor`.

# Link to issue
Closes #51 