### PR TITLE
Add possibility to adjust headers per request

### DIFF
--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -96,14 +96,14 @@ public final class Client {
     @discardableResult
     public func get<ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
-        additionalHeaderFields: [String: String] = [:],
+        andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:],
         _ completion: @escaping RequestCompletion<ResponseType>
     ) -> CancellableRequest? {
         do {
             let request: URLRequest = try createRequest(
                 forHttpMethod: .GET,
                 and: endpoint,
-                additionalHeaderFields: additionalHeaderFields
+                andAdditionalHeaderFields: additionalHeaderFields
             )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
@@ -127,7 +127,7 @@ public final class Client {
     public func post<BodyType: Encodable, ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
         body: BodyType,
-        additionalHeaderFields: [String: String] = [:],
+        andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:],
         _ completion: @escaping RequestCompletion<ResponseType>
     ) -> CancellableRequest? {
         do {
@@ -137,7 +137,7 @@ public final class Client {
                 forHttpMethod: .POST,
                 and: endpoint,
                 and: bodyData,
-                additionalHeaderFields: additionalHeaderFields
+                andAdditionalHeaderFields: additionalHeaderFields
             )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
@@ -161,14 +161,14 @@ public final class Client {
     public func post<ResponseType>(
         endpoint: Endpoint<ResponseType>,
         body: ExpressibleByNilLiteral? = nil,
-        additionalHeaderFields: [String: String] = [:],
+        andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:],
         _ completion: @escaping RequestCompletion<ResponseType>
     ) -> CancellableRequest? {
         do {
             let request: URLRequest = try createRequest(
                 forHttpMethod: .POST,
                 and: endpoint,
-                additionalHeaderFields: additionalHeaderFields
+                andAdditionalHeaderFields: additionalHeaderFields
             )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
@@ -192,7 +192,7 @@ public final class Client {
     public func put<BodyType: Encodable, ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
         body: BodyType,
-        additionalHeaderFields: [String: String] = [:],
+        andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:],
         _ completion: @escaping RequestCompletion<ResponseType>
     ) -> CancellableRequest? {
         do {
@@ -202,7 +202,7 @@ public final class Client {
                 forHttpMethod: .PUT,
                 and: endpoint,
                 and: bodyData,
-                additionalHeaderFields: additionalHeaderFields
+                andAdditionalHeaderFields: additionalHeaderFields
             )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
@@ -226,7 +226,7 @@ public final class Client {
     public func patch<BodyType: Encodable, ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
         body: BodyType,
-        additionalHeaderFields: [String: String] = [:],
+        andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:],
         _ completion: @escaping RequestCompletion<ResponseType>
     ) -> CancellableRequest? {
         do {
@@ -236,7 +236,7 @@ public final class Client {
                 forHttpMethod: .PATCH,
                 and: endpoint,
                 and: bodyData,
-                additionalHeaderFields: additionalHeaderFields
+                andAdditionalHeaderFields: additionalHeaderFields
             )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
@@ -260,14 +260,14 @@ public final class Client {
     public func delete<ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
         parameter: [String: Any] = [:],
-        additionalHeaderFields: [String: String] = [:],
+        andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:],
         _ completion: @escaping RequestCompletion<ResponseType>
     ) -> CancellableRequest? {
         do {
             let request: URLRequest = try createRequest(
                 forHttpMethod: .DELETE,
                 and: endpoint,
-                additionalHeaderFields: additionalHeaderFields
+                andAdditionalHeaderFields: additionalHeaderFields
             )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
@@ -387,7 +387,7 @@ public final class Client {
         forHttpMethod httpMethod: HTTPMethod,
         and endpoint: Endpoint<ResponseType>,
         and body: Data? = nil,
-        additionalHeaderFields: [String: String]
+        andAdditionalHeaderFields additionalHeaderFields: [String: String]
     ) throws -> URLRequest {
         var request = URLRequest(
             url: try URLFactory.makeURL(from: endpoint, withBaseURL: configuration.baseURL),

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -94,9 +94,17 @@ public final class Client {
 
     // MARK: - Methods
     @discardableResult
-    public func get<ResponseType: Decodable>(endpoint: Endpoint<ResponseType>, _ completion: @escaping RequestCompletion<ResponseType>) -> CancellableRequest? {
+    public func get<ResponseType: Decodable>(
+        endpoint: Endpoint<ResponseType>,
+        additionalHeaderFields: [String: String] = [:],
+        _ completion: @escaping RequestCompletion<ResponseType>
+    ) -> CancellableRequest? {
         do {
-            let request: URLRequest = try createRequest(forHttpMethod: .GET, and: endpoint)
+            let request: URLRequest = try createRequest(
+                forHttpMethod: .GET,
+                and: endpoint,
+                additionalHeaderFields: additionalHeaderFields
+            )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
@@ -116,11 +124,21 @@ public final class Client {
     }
 
     @discardableResult
-    public func post<BodyType: Encodable, ResponseType: Decodable>(endpoint: Endpoint<ResponseType>, body: BodyType, _ completion: @escaping RequestCompletion<ResponseType>) -> CancellableRequest? {
+    public func post<BodyType: Encodable, ResponseType: Decodable>(
+        endpoint: Endpoint<ResponseType>,
+        body: BodyType,
+        additionalHeaderFields: [String: String] = [:],
+        _ completion: @escaping RequestCompletion<ResponseType>
+    ) -> CancellableRequest? {
         do {
             let encoder: Encoder = endpoint.encoder ?? configuration.encoder
             let bodyData: Data = try encoder.encode(body)
-            let request: URLRequest = try createRequest(forHttpMethod: .POST, and: endpoint, and: bodyData)
+            let request: URLRequest = try createRequest(
+                forHttpMethod: .POST,
+                and: endpoint,
+                and: bodyData,
+                additionalHeaderFields: additionalHeaderFields
+            )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
@@ -140,9 +158,18 @@ public final class Client {
     }
 
     @discardableResult
-    public func post<ResponseType>(endpoint: Endpoint<ResponseType>, body: ExpressibleByNilLiteral? = nil, _ completion: @escaping RequestCompletion<ResponseType>) -> CancellableRequest? {
+    public func post<ResponseType>(
+        endpoint: Endpoint<ResponseType>,
+        body: ExpressibleByNilLiteral? = nil,
+        additionalHeaderFields: [String: String] = [:],
+        _ completion: @escaping RequestCompletion<ResponseType>
+    ) -> CancellableRequest? {
         do {
-            let request: URLRequest = try createRequest(forHttpMethod: .POST, and: endpoint)
+            let request: URLRequest = try createRequest(
+                forHttpMethod: .POST,
+                and: endpoint,
+                additionalHeaderFields: additionalHeaderFields
+            )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
@@ -162,11 +189,21 @@ public final class Client {
     }
 
     @discardableResult
-    public func put<BodyType: Encodable, ResponseType: Decodable>(endpoint: Endpoint<ResponseType>, body: BodyType, _ completion: @escaping RequestCompletion<ResponseType>) -> CancellableRequest? {
+    public func put<BodyType: Encodable, ResponseType: Decodable>(
+        endpoint: Endpoint<ResponseType>,
+        body: BodyType,
+        additionalHeaderFields: [String: String] = [:],
+        _ completion: @escaping RequestCompletion<ResponseType>
+    ) -> CancellableRequest? {
         do {
             let encoder: Encoder = endpoint.encoder ?? configuration.encoder
             let bodyData: Data = try encoder.encode(body)
-            let request: URLRequest = try createRequest(forHttpMethod: .PUT, and: endpoint, and: bodyData)
+            let request: URLRequest = try createRequest(
+                forHttpMethod: .PUT,
+                and: endpoint,
+                and: bodyData,
+                additionalHeaderFields: additionalHeaderFields
+            )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
@@ -189,12 +226,18 @@ public final class Client {
     public func patch<BodyType: Encodable, ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
         body: BodyType,
+        additionalHeaderFields: [String: String] = [:],
         _ completion: @escaping RequestCompletion<ResponseType>
     ) -> CancellableRequest? {
         do {
             let encoder: Encoder = endpoint.encoder ?? configuration.encoder
             let bodyData: Data = try encoder.encode(body)
-            let request: URLRequest = try createRequest(forHttpMethod: .PATCH, and: endpoint, and: bodyData)
+            let request: URLRequest = try createRequest(
+                forHttpMethod: .PATCH,
+                and: endpoint,
+                and: bodyData,
+                additionalHeaderFields: additionalHeaderFields
+            )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
@@ -214,9 +257,18 @@ public final class Client {
     }
 
     @discardableResult
-    public func delete<ResponseType: Decodable>(endpoint: Endpoint<ResponseType>, parameter: [String: Any] = [:], _ completion: @escaping RequestCompletion<ResponseType>) -> CancellableRequest? {
+    public func delete<ResponseType: Decodable>(
+        endpoint: Endpoint<ResponseType>,
+        parameter: [String: Any] = [:],
+        additionalHeaderFields: [String: String] = [:],
+        _ completion: @escaping RequestCompletion<ResponseType>
+    ) -> CancellableRequest? {
         do {
-            let request: URLRequest = try createRequest(forHttpMethod: .DELETE, and: endpoint)
+            let request: URLRequest = try createRequest(
+                forHttpMethod: .DELETE,
+                and: endpoint,
+                additionalHeaderFields: additionalHeaderFields
+            )
             return requestExecuter.send(request: request) { [weak self] data, urlResponse, error in
                 guard let self = self else { return }
 
@@ -334,9 +386,10 @@ public final class Client {
     private func createRequest<ResponseType>(
         forHttpMethod httpMethod: HTTPMethod,
         and endpoint: Endpoint<ResponseType>,
-        and body: Data? = nil
+        and body: Data? = nil,
+        additionalHeaderFields: [String: String]
     ) throws -> URLRequest {
-        let request = URLRequest(
+        var request = URLRequest(
             url: try URLFactory.makeURL(from: endpoint, withBaseURL: configuration.baseURL),
             httpMethod: httpMethod,
             httpBody: body
@@ -355,6 +408,11 @@ public final class Client {
                 EmptyContentHeaderFieldsRequestInterceptor(),
                 at: indexToInsert ?? requestInterceptors.endIndex
             )
+        }
+
+        // Append additional header fields.
+        additionalHeaderFields.forEach { key, value in
+            request.addValue(value, forHTTPHeaderField: key)
         }
 
         return requestInterceptors.reduce(request) { request, interceptor in

--- a/Tests/JetworkingTests/ClientTests/AdditionalHeaderTests.swift
+++ b/Tests/JetworkingTests/ClientTests/AdditionalHeaderTests.swift
@@ -29,7 +29,7 @@ final class AdditionalHeaderTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for get")
         client.get(
             endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue"),
-            additionalHeaderFields: testHeader
+            andAdditionalHeaderFields: testHeader
         ) { response, result in
             switch result {
             case .failure:
@@ -70,7 +70,7 @@ final class AdditionalHeaderTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for get")
         client.get(
             endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue"),
-            additionalHeaderFields: testHeader
+            andAdditionalHeaderFields: testHeader
         ) { response, result in
             switch result {
             case .failure:
@@ -111,7 +111,7 @@ final class AdditionalHeaderTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for get")
         client.get(
             endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue"),
-            additionalHeaderFields: testHeader
+            andAdditionalHeaderFields: testHeader
         ) { response, result in
             switch result {
             case .failure:

--- a/Tests/JetworkingTests/ClientTests/AdditionalHeaderTests.swift
+++ b/Tests/JetworkingTests/ClientTests/AdditionalHeaderTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import XCTest
+import Foundation
+@testable import Jetworking
+
+final class AdditionalHeaderTests: XCTestCase {
+    let testHeader: [String: String] = ["SomeHeaderKey": "SomeHeaderValue"]
+
+    override class func tearDown() {
+        super.tearDown()
+
+        MockExecuter.validateHeaderFields = nil
+    }
+
+    func testAdditionalHeadersForGet() {
+        let client = Client(configuration: Configurations.default()) { session in
+            session.configuration.timeoutIntervalForRequest = 30
+        }
+
+        let validatedHeaders = self.expectation(description: "Headers are validated")
+        MockExecuter.validateHeaderFields = { [unowned self] requestHeaders in
+            self.testHeader.forEach { headerEntry in
+                XCTAssertEqual(requestHeaders?[headerEntry.key], headerEntry.value)
+            }
+
+            validatedHeaders.fulfill()
+        }
+
+        let expectation = self.expectation(description: "Wait for get")
+        client.get(
+            endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue"),
+            additionalHeaderFields: testHeader
+        ) { response, result in
+            switch result {
+            case .failure:
+                XCTFail("Request should not result in failure!")
+
+            case let .success(resultData):
+                XCTAssertEqual(MockBody(foo1: "SomeFoo", foo2: "AnotherFoo"), resultData)
+            }
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation, validatedHeaders], timeout: 2)
+    }
+
+    func testAdditionalHeadersShouldBeMergedWithGlobalOnes() {
+        let globalHeaderFields: [String: String] = ["GlobalHeaderKey": "GlobalHeaderValue"]
+        let configuration: Configuration = Configurations.default(globalHeaderFields: globalHeaderFields)
+        let client = Client(configuration: configuration) { session in
+            session.configuration.timeoutIntervalForRequest = 30
+        }
+
+        let validatedHeaders = self.expectation(description: "Headers are validated")
+
+        let mergedHeaders: [String: String] = globalHeaderFields.merging(testHeader) { lhs, rhs in
+            // Merging of header values is switched in URLRequest
+            return [rhs, lhs].joined(separator: ",")
+        }
+
+        MockExecuter.validateHeaderFields = { requestHeaders in
+            mergedHeaders.forEach { headerEntry in
+                XCTAssertEqual(requestHeaders?[headerEntry.key], headerEntry.value)
+            }
+
+            validatedHeaders.fulfill()
+        }
+
+        let expectation = self.expectation(description: "Wait for get")
+        client.get(
+            endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue"),
+            additionalHeaderFields: testHeader
+        ) { response, result in
+            switch result {
+            case .failure:
+                XCTFail("Request should not result in failure!")
+
+            case let .success(resultData):
+                XCTAssertEqual(MockBody(foo1: "SomeFoo", foo2: "AnotherFoo"), resultData)
+            }
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation, validatedHeaders], timeout: 2)
+    }
+
+    func testAdditionalHeadersShouldBeMergedWithGlobalJoinedKeys() {
+        let globalHeaderFields: [String: String] = ["SomeHeaderKey": "GlobalHeaderValue"]
+        let configuration: Configuration = Configurations.default(globalHeaderFields: globalHeaderFields)
+        let client = Client(configuration: configuration) { session in
+            session.configuration.timeoutIntervalForRequest = 30
+        }
+
+        let validatedHeaders = self.expectation(description: "Headers are validated")
+
+        let mergedHeaders: [String: String] = globalHeaderFields.merging(testHeader) { lhs, rhs in
+            // Merging of header values is switched in URLRequest
+            return [rhs, lhs].joined(separator: ",")
+        }
+
+        MockExecuter.validateHeaderFields = { requestHeaders in
+            mergedHeaders.forEach { headerEntry in
+                XCTAssertEqual(requestHeaders?[headerEntry.key], headerEntry.value)
+            }
+
+            validatedHeaders.fulfill()
+        }
+
+        let expectation = self.expectation(description: "Wait for get")
+        client.get(
+            endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue"),
+            additionalHeaderFields: testHeader
+        ) { response, result in
+            switch result {
+            case .failure:
+                XCTFail("Request should not result in failure!")
+
+            case let .success(resultData):
+                XCTAssertEqual(MockBody(foo1: "SomeFoo", foo2: "AnotherFoo"), resultData)
+            }
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation, validatedHeaders], timeout: 2)
+    }
+}

--- a/Tests/JetworkingTests/Mocks/Configurations.swift
+++ b/Tests/JetworkingTests/Mocks/Configurations.swift
@@ -2,14 +2,17 @@ import Foundation
 @testable import Jetworking
 
 enum Configurations {
-    static func `default`(_ requestExecuterType: RequestExecuterType = .custom(MockExecuter.self)) -> Configuration {
+    static func `default`(
+        _ requestExecuterType: RequestExecuterType = .custom(MockExecuter.self),
+        globalHeaderFields: [String: String] = HeaderFields.additional
+    ) -> Configuration {
         return .init(
             baseURL: URL(string: "https://www.jamitlabs.com/")!,
             interceptors: [
                 AuthenticationRequestInterceptor(
                     authenticationMethod: .basicAuthentication(username: "username", password: "password")
                 ),
-                HeaderFieldsRequestInterceptor(headerFields: HeaderFields.additional),
+                HeaderFieldsRequestInterceptor(headerFields: globalHeaderFields),
                 LoggingInterceptor()
             ],
             requestExecuterType: requestExecuterType

--- a/Tests/JetworkingTests/Mocks/MockExecuter.swift
+++ b/Tests/JetworkingTests/Mocks/MockExecuter.swift
@@ -23,6 +23,7 @@ final class MockExecuter: RequestExecuter {
     var isCancelled: Bool = false
 
     static var completionDelayForRequest: ((URLRequest) -> TimeInterval)?
+    static var validateHeaderFields: (([String: String]?) -> Void)?
 
     init(session: URLSession) {
         self.session = session
@@ -56,6 +57,7 @@ final class MockExecuter: RequestExecuter {
         request: URLRequest,
         completion: @escaping ((Data?, URLResponse?, Error?) -> Void)
     ) {
+        MockExecuter.validateHeaderFields?(request.allHTTPHeaderFields)
         completion(
             try? encoder.encode(MockBody(foo1: "SomeFoo", foo2: "AnotherFoo")),
             request.toHTTPURLResponse(


### PR DESCRIPTION
All http functions are now possible to pass additional headers to the request. If a key is already present as header key the values are merged.

Download and upload functions are not touched.