### PR TITLE
[#81] Add possiblity to pass a preconfigured session to the client

### DIFF
--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -15,7 +15,7 @@ public final class Client {
 
     private let configuration: Configuration
 
-    private lazy var session: URLSession = .init(configuration: .default)
+    private let session: URLSession
     private lazy var responseHandler: ResponseHandler = .init(configuration: configuration)
 
     private lazy var requestExecuter: RequestExecuter = {
@@ -82,14 +82,14 @@ public final class Client {
      * Initialises a new client instance with a default url session.
      *
      * - Parameter configuration: The client configuration.
-     * - Parameter sessionConfiguration: A function to configure the URLSession as inout parameter.
+     * - Parameter session: The URLSession which is used for executing requests
      */
     public init(
         configuration: Configuration,
-        sessionConfiguration: ((inout URLSession) -> Void)? = nil
+        session: URLSession = .init(configuration: .default)
     ) {
         self.configuration = configuration
-        sessionConfiguration?(&session)
+        self.session = session
     }
 
     // MARK: - Methods

--- a/Tests/JetworkingTests/ClientTests/AdditionalHeaderTests.swift
+++ b/Tests/JetworkingTests/ClientTests/AdditionalHeaderTests.swift
@@ -5,6 +5,11 @@ import Foundation
 
 final class AdditionalHeaderTests: XCTestCase {
     let testHeader: [String: String] = ["SomeHeaderKey": "SomeHeaderValue"]
+    var defaultSession: URLSession = {
+        var session = URLSession(configuration: .default)
+        session.configuration.timeoutIntervalForRequest = 30
+        return session
+    }()
 
     override class func tearDown() {
         super.tearDown()
@@ -13,10 +18,7 @@ final class AdditionalHeaderTests: XCTestCase {
     }
 
     func testAdditionalHeadersForGet() {
-        let client = Client(configuration: Configurations.default()) { session in
-            session.configuration.timeoutIntervalForRequest = 30
-        }
-
+        let client = Client(configuration: Configurations.default(), session: defaultSession)
         let validatedHeaders = self.expectation(description: "Headers are validated")
         MockExecuter.validateHeaderFields = { [unowned self] requestHeaders in
             self.testHeader.forEach { headerEntry in
@@ -48,9 +50,7 @@ final class AdditionalHeaderTests: XCTestCase {
     func testAdditionalHeadersShouldBeMergedWithGlobalOnes() {
         let globalHeaderFields: [String: String] = ["GlobalHeaderKey": "GlobalHeaderValue"]
         let configuration: Configuration = Configurations.default(globalHeaderFields: globalHeaderFields)
-        let client = Client(configuration: configuration) { session in
-            session.configuration.timeoutIntervalForRequest = 30
-        }
+        let client = Client(configuration: configuration, session: defaultSession)
 
         let validatedHeaders = self.expectation(description: "Headers are validated")
 
@@ -89,9 +89,7 @@ final class AdditionalHeaderTests: XCTestCase {
     func testAdditionalHeadersShouldBeMergedWithGlobalJoinedKeys() {
         let globalHeaderFields: [String: String] = ["SomeHeaderKey": "GlobalHeaderValue"]
         let configuration: Configuration = Configurations.default(globalHeaderFields: globalHeaderFields)
-        let client = Client(configuration: configuration) { session in
-            session.configuration.timeoutIntervalForRequest = 30
-        }
+        let client = Client(configuration: configuration, session: defaultSession)
 
         let validatedHeaders = self.expectation(description: "Headers are validated")
 

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -3,11 +3,14 @@ import Foundation
 @testable import Jetworking
 
 final class ClientTests: XCTestCase {
-    func testGetRequest() {
-        let client = Client(configuration: Configurations.default()) { session in
-            session.configuration.timeoutIntervalForRequest = 30
-        }
+    var defaultSession: URLSession = {
+        var session = URLSession(configuration: .default)
+        session.configuration.timeoutIntervalForRequest = 30
+        return session
+    }()
 
+    func testGetRequest() {
+        let client = Client(configuration: Configurations.default(), session: defaultSession)
         let expectation = self.expectation(description: "Wait for get")
 
         client.get(endpoint: Endpoints.get.addQueryParameter(key: "SomeKey", value: "SomeValue")) { response, result in

--- a/Tests/JetworkingTests/ClientTests/CustomDecoderTests.swift
+++ b/Tests/JetworkingTests/ClientTests/CustomDecoderTests.swift
@@ -3,11 +3,15 @@ import Foundation
 @testable import Jetworking
 
 final class CustomDecoderTests: XCTestCase {
+    var defaultSession: URLSession = {
+        var session = URLSession(configuration: .default)
+        session.configuration.timeoutIntervalForRequest = 30
+        return session
+    }()
+
     func testCustomDecoderForGet() {
         let testableDecoder = TestableDecoder()
-        let client = Client(configuration: Configurations.default(.custom(MockExecuter.self))) { session in
-            session.configuration.timeoutIntervalForRequest = 30
-        }
+        let client = Client(configuration: Configurations.default(.custom(MockExecuter.self)), session: defaultSession)
 
         let getDecoderCalledExpectation = expectation(description: "Decoder method called for get")
         let waitForGetExpectation = expectation(description: "Wait for get")
@@ -37,9 +41,7 @@ final class CustomDecoderTests: XCTestCase {
 
     func testCustomDecoderForPost() {
         let testableDecoder = TestableDecoder()
-        let client = Client(configuration: Configurations.default(.custom(MockExecuter.self))) { session in
-            session.configuration.timeoutIntervalForRequest = 30
-        }
+        let client = Client(configuration: Configurations.default(.custom(MockExecuter.self)), session: defaultSession)
 
         let postDecodingCalledExpectation = expectation(description: "Decoder method called for post")
         let waitForPostExpectation = expectation(description: "Wait for post")
@@ -70,9 +72,7 @@ final class CustomDecoderTests: XCTestCase {
 
     func testCustomDecoderForPut() {
         let testableDecoder = TestableDecoder()
-        let client = Client(configuration: Configurations.default(.custom(MockExecuter.self))) { session in
-            session.configuration.timeoutIntervalForRequest = 30
-        }
+        let client = Client(configuration: Configurations.default(.custom(MockExecuter.self)), session: defaultSession)
 
         let putDecodingCalledExpectation = expectation(description: "Decoder method called for put")
         let waitForPutExpectation = expectation(description: "Wait for put")
@@ -102,9 +102,7 @@ final class CustomDecoderTests: XCTestCase {
 
     func testCustomDecoderForPatch() {
         let testableDecoder = TestableDecoder()
-        let client = Client(configuration: Configurations.default(.custom(MockExecuter.self))) { session in
-            session.configuration.timeoutIntervalForRequest = 30
-        }
+        let client = Client(configuration: Configurations.default(.custom(MockExecuter.self)), session: defaultSession)
 
         let patchDecodingCalledExpectation = expectation(description: "Decoder method called for patch")
         let waitForPatchExpectation = expectation(description: "Wait for patch")


### PR DESCRIPTION
Since we need to set the session delegate which is only possible on session creation I moved the URL session as a parameter to the client initializer. This will add the most flexibility for session configuration. The default session configuration is used as default value in initializer.

this PR is closing #81