### PR TITLE
Make ApiError public

### DIFF
--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-enum APIError: Error {
+/// An error occuring  while sending a request
+public enum APIError: Error {
     case unexpectedError
     case responseMissing
     case decodingError(Error)


### PR DESCRIPTION
To a user of this framework it would be useful to see the exact errors raised by the api