### PR TITLE
Make makeURL a public method

### DIFF
--- a/Sources/Jetworking/Utility/URLFactory.swift
+++ b/Sources/Jetworking/Utility/URLFactory.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum URLFactory {
-    static func makeURL<ResponseType>(from endpoint: Endpoint<ResponseType>, withBaseURL baseURL: URL) throws -> URL {
+    public static func makeURL<ResponseType>(from endpoint: Endpoint<ResponseType>, withBaseURL baseURL: URL) throws -> URL {
         let currentURL = endpoint.pathComponents.reduce(into: baseURL) { (url, pathComponent) in
             url.appendPathComponent(pathComponent)
         }


### PR DESCRIPTION
We should also publish the factory method of the (already public) URLFactory. This would help with unit testing mocked url requests.