### PR TITLE
Add possiblity to pass response body on client and server error

### DIFF
--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -5,8 +5,8 @@ public enum APIError: Error {
     case unexpectedError
     case responseMissing
     case decodingError(Error)
-    case clientError(statusCode: Int, error: Error?)
-    case serverError(statusCode: Int, error: Error?)
+    case clientError(statusCode: Int, error: Error?, body: Data?)
+    case serverError(statusCode: Int, error: Error?, body: Data?)
     case missingResponseBody
     case invalidURLComponents
 }

--- a/Sources/Jetworking/Client/ResponseHandler.swift
+++ b/Sources/Jetworking/Client/ResponseHandler.swift
@@ -95,7 +95,8 @@ final class ResponseHandler {
         case .serverError:
             let apiError: APIError = APIError.serverError(
                 statusCode: currentURLResponse.statusCode,
-                error: error
+                error: error,
+                body: data
             )
 
             return enqueue(
@@ -106,7 +107,8 @@ final class ResponseHandler {
         case .clientError:
             let apiError: APIError = APIError.clientError(
                 statusCode: currentURLResponse.statusCode,
-                error: error
+                error: error,
+                body: data
             )
 
             enqueue(

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -198,7 +198,7 @@ final class ClientTests: XCTestCase {
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
 
             switch result {
-            case .failure(APIError.serverError(statusCode: 500, error: _)):
+            case .failure(APIError.serverError(statusCode: 500, error: _, body: _)):
                 XCTAssertNotNil(response)
                 XCTAssertEqual(response?.statusCode, 500)
                 expectation.fulfill()
@@ -221,7 +221,7 @@ final class ClientTests: XCTestCase {
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
 
             switch result {
-            case .failure(APIError.clientError(statusCode: 403, error: _)):
+            case .failure(APIError.clientError(statusCode: 403, error: _, body: _)):
                 XCTAssertNotNil(response)
                 XCTAssertEqual(response?.statusCode, 403)
                 expectation.fulfill()


### PR DESCRIPTION
This PR is adding the possibility to handle the response body if an server error or client error occurs ( HTTP Status code >= 400).

The body is passed as optional.