### PR TITLE
Add BaseURLProvider protocol to pass dynamic base URLs

### DIFF
--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -394,7 +394,7 @@ public final class Client {
         andAdditionalHeaderFields additionalHeaderFields: [String: String]
     ) throws -> URLRequest {
         var request = URLRequest(
-            url: try URLFactory.makeURL(from: endpoint, withBaseURL: configuration.baseURL),
+            url: try URLFactory.makeURL(from: endpoint, withBaseURL: configuration.baseURLProvider.baseURL),
             httpMethod: httpMethod,
             httpBody: body
         )

--- a/Sources/Jetworking/Client/Configuration/BaseURLProvider/BaseURLProvider.swift
+++ b/Sources/Jetworking/Client/Configuration/BaseURLProvider/BaseURLProvider.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol BaseURLProvider {
+    var baseURL: URL { get }
+}

--- a/Sources/Jetworking/Client/Configuration/Configuration.swift
+++ b/Sources/Jetworking/Client/Configuration/Configuration.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The configuration used within the client.
 public struct Configuration {
-    let baseURL: URL
+    let baseURLProvider: BaseURLProvider
     let interceptors: [Interceptor]
     let encoder: Encoder
     let decoder: Decoder
@@ -25,7 +25,7 @@ public struct Configuration {
     /**
      * Initialises a new configuration instance to use within the client.
      *
-     * - Parameter baseURL: The base URL used within the client.
+     * - Parameter baseURLProvider: The provider which provides the base URL used within the client. Note: URL itself is implementing the protocol itself to pass a static baseURL.
      * - Parameter interceptors: A list of interceptors to intercept the request before sending (`RequestInterceptor`) it or intersect the response after receiving it (`ResponseInterceptor`).
      * - Parameter encoder: The standard encoder to use to encode the request body data before sending it.
      * - Parameter decoder: The standard decoder to use to decode the response body data before returning it.
@@ -35,7 +35,7 @@ public struct Configuration {
      * - Parameter cache: A cache object that realizes caching mechanism. IMPORTANT: At least one instance of `SessionCacheInterceptor` is required.
      */
     public init(
-        baseURL: URL,
+        baseURLProvider: BaseURLProvider,
         interceptors: [Interceptor],
         encoder: Encoder = JSONEncoder(),
         decoder: Decoder = JSONDecoder(),
@@ -45,7 +45,7 @@ public struct Configuration {
         responseQueue: DispatchQueue = .main,
         cache: URLCache = .shared
     ) {
-        self.baseURL = baseURL
+        self.baseURLProvider = baseURLProvider
         self.interceptors = interceptors
         self.encoder = encoder
         self.decoder = decoder

--- a/Sources/Jetworking/Extensions/URL+BaseURLProvider.swift
+++ b/Sources/Jetworking/Extensions/URL+BaseURLProvider.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+// NOTE: Extension to use URL as static base URL provider
+extension URL: BaseURLProvider {
+    public var baseURL: URL { self }
+}

--- a/Tests/JetworkingTests/ClientTests/ClientTests.swift
+++ b/Tests/JetworkingTests/ClientTests/ClientTests.swift
@@ -169,7 +169,7 @@ final class ClientTests: XCTestCase {
 
         let expectation = self.expectation(description: "Wait for an external request")
 
-        let url = try? URLFactory.makeURL(from: Endpoints.delete, withBaseURL: defaultConfiguration.baseURL)
+        let url = try? URLFactory.makeURL(from: Endpoints.delete, withBaseURL: defaultConfiguration.baseURLProvider.baseURL)
         guard let targetURL = url else {
             XCTFail("URL not available")
             return

--- a/Tests/JetworkingTests/Mocks/Configurations.swift
+++ b/Tests/JetworkingTests/Mocks/Configurations.swift
@@ -7,7 +7,7 @@ enum Configurations {
         globalHeaderFields: [String: String] = HeaderFields.additional
     ) -> Configuration {
         return .init(
-            baseURL: URL(string: "https://www.jamitlabs.com/")!,
+            baseURLProvider: URL(string: "https://www.jamitlabs.com/")!,
             interceptors: [
                 AuthenticationRequestInterceptor(
                     authenticationMethod: .basicAuthentication(username: "username", password: "password")
@@ -21,7 +21,7 @@ enum Configurations {
 
     static func extendClientConfiguration(_ configuration: Configuration, with cache: URLCache) -> Configuration {
         return .init(
-            baseURL: configuration.baseURL,
+            baseURLProvider: configuration.baseURLProvider,
             interceptors: configuration.interceptors + [DefaultSessionCacheIntercepter()],
             encoder: configuration.encoder,
             decoder: configuration.decoder,


### PR DESCRIPTION
To improve the flexibility of our framework we introduce the `BaseURLProvider` protocol. This adds the possibility to change the base URL of a client dynamically.
To reduce complexity in configuration, Foundations `URL` implements the protocol by default, therefore it is possible to pass a static base URL.