### PR TITLE
WIP: Adding async await API to GET, POST, PUT, PATCH, DELETE and simple request.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -439,7 +439,7 @@ extension Client {
 extension Client {
     public typealias RequestResult<ResponseType> = (HTTPURLResponse?, Result<ResponseType, Error>)
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     public func get<ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
         andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:]
@@ -462,7 +462,7 @@ extension Client {
         }
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     @discardableResult
     public func post<BodyType: Encodable, ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
@@ -490,7 +490,7 @@ extension Client {
         }
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     @discardableResult
     public func post<ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
@@ -515,7 +515,7 @@ extension Client {
         }
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     @discardableResult
     public func put<BodyType: Encodable, ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
@@ -543,7 +543,7 @@ extension Client {
         }
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     @discardableResult
     public func patch<BodyType: Encodable, ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
@@ -571,7 +571,7 @@ extension Client {
         }
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     @discardableResult
     public func delete<ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,
@@ -596,7 +596,7 @@ extension Client {
         }
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     @discardableResult
     public func send(request: URLRequest) async -> (Data?, URLResponse?, Error?) {
         do {

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -454,6 +454,17 @@ public final class Client {
         return requestExecuter.send(request: request, completion)
     }
 
+    @available(iOS 15.0, macOS 12.0, *)
+    @discardableResult
+    public func send(request: URLRequest) async -> (Data?, URLResponse?, Error?) {
+        do {
+            let (data, urlResponse) = try await requestExecuter.send(request: request, delegate: nil)
+            return (data, urlResponse, nil)
+        } catch {
+            return (nil, nil, error)
+        }
+    }
+
     @discardableResult
     public func download(
         url: URL,

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -184,6 +184,34 @@ public final class Client {
 
         return nil
     }
+    
+    @available(iOS 15.0, macOS 12.0, *)
+    @discardableResult
+    public func post<BodyType: Encodable, ResponseType: Decodable>(
+        endpoint: Endpoint<ResponseType>,
+        body: BodyType,
+        andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:]
+    ) async -> RequestResult<ResponseType> {
+        do {
+            let encoder: Encoder = endpoint.encoder ?? configuration.encoder
+            let bodyData: Data = try encoder.encode(body)
+            let request: URLRequest = try createRequest(
+                forHttpMethod: .POST,
+                and: endpoint,
+                and: bodyData,
+                andAdditionalHeaderFields: additionalHeaderFields
+            )
+
+            let (data, urlResponse) = try await requestExecuter.send(request: request, delegate: nil)
+            return await responseHandler.handleDecodableResponse(
+                data: data,
+                urlResponse: urlResponse,
+                endpoint: endpoint
+            )
+        } catch {
+            return (nil, .failure(error))
+        }
+    }
 
     @discardableResult
     public func post<ResponseType>(
@@ -214,6 +242,31 @@ public final class Client {
         }
 
         return nil
+    }
+
+    @available(iOS 15.0, macOS 12.0, *)
+    @discardableResult
+    public func post<ResponseType: Decodable>(
+        endpoint: Endpoint<ResponseType>,
+        body: ExpressibleByNilLiteral? = nil,
+        andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:]
+    ) async -> RequestResult<ResponseType> {
+        do {
+            let request: URLRequest = try createRequest(
+                forHttpMethod: .POST,
+                and: endpoint,
+                andAdditionalHeaderFields: additionalHeaderFields
+            )
+
+            let (data, urlResponse) = try await requestExecuter.send(request: request, delegate: nil)
+            return await responseHandler.handleDecodableResponse(
+                data: data,
+                urlResponse: urlResponse,
+                endpoint: endpoint
+            )
+        } catch {
+            return (nil, .failure(error))
+        }
     }
 
     @discardableResult

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -424,6 +424,31 @@ public final class Client {
         return nil
     }
 
+    @available(iOS 15.0, macOS 12.0, *)
+    @discardableResult
+    public func delete<ResponseType: Decodable>(
+        endpoint: Endpoint<ResponseType>,
+        parameter: [String: Any] = [:],
+        andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:]
+    ) async -> RequestResult<ResponseType> {
+        do {
+            let request: URLRequest = try createRequest(
+                forHttpMethod: .DELETE,
+                and: endpoint,
+                andAdditionalHeaderFields: additionalHeaderFields
+            )
+
+            let (data, urlResponse) = try await requestExecuter.send(request: request, delegate: nil)
+            return await responseHandler.handleDecodableResponse(
+                data: data,
+                urlResponse: urlResponse,
+                endpoint: endpoint
+            )
+        } catch {
+            return (nil, .failure(error))
+        }
+    }
+
     @discardableResult
     public func send(request: URLRequest, _ completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> CancellableRequest? {
         return requestExecuter.send(request: request, completion)

--- a/Sources/Jetworking/Client/Client.swift
+++ b/Sources/Jetworking/Client/Client.swift
@@ -365,6 +365,34 @@ public final class Client {
         return nil
     }
 
+    @available(iOS 15.0, macOS 12.0, *)
+    @discardableResult
+    public func patch<BodyType: Encodable, ResponseType: Decodable>(
+        endpoint: Endpoint<ResponseType>,
+        body: BodyType,
+        andAdditionalHeaderFields additionalHeaderFields: [String: String] = [:]
+    ) async -> RequestResult<ResponseType> {
+        do {
+            let encoder: Encoder = endpoint.encoder ?? configuration.encoder
+            let bodyData: Data = try encoder.encode(body)
+            let request: URLRequest = try createRequest(
+                forHttpMethod: .PATCH,
+                and: endpoint,
+                and: bodyData,
+                andAdditionalHeaderFields: additionalHeaderFields
+            )
+
+            let (data, urlResponse) = try await requestExecuter.send(request: request, delegate: nil)
+            return await responseHandler.handleDecodableResponse(
+                data: data,
+                urlResponse: urlResponse,
+                endpoint: endpoint
+            )
+        } catch {
+            return (nil, .failure(error))
+        }
+    }
+
     @discardableResult
     public func delete<ResponseType: Decodable>(
         endpoint: Endpoint<ResponseType>,

--- a/Sources/Jetworking/Client/Executor/RequestExecuter/AsyncRequestExecuter/AsyncRequestExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/RequestExecuter/AsyncRequestExecuter/AsyncRequestExecuter.swift
@@ -13,4 +13,9 @@ final class AsyncRequestExecuter: RequestExecuter {
 
         return dataTask
     }
+
+    @available(iOS 15.0, macOS 12.0, *)
+    func send(request: URLRequest, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data?, URLResponse?) {
+        return try await session.data(for: request, delegate: delegate)
+    }
 }

--- a/Sources/Jetworking/Client/Executor/RequestExecuter/AsyncRequestExecuter/AsyncRequestExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/RequestExecuter/AsyncRequestExecuter/AsyncRequestExecuter.swift
@@ -14,8 +14,12 @@ final class AsyncRequestExecuter: RequestExecuter {
         return dataTask
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     func send(request: URLRequest, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data?, URLResponse?) {
-        return try await session.data(for: request, delegate: delegate)
+        if #available(iOS 15.0, macOS 12.0, *) {
+            return try await session.data(for: request, delegate: delegate)
+        } else {
+            return try await session.data(for: request)
+        }
     }
 }

--- a/Sources/Jetworking/Client/Executor/RequestExecuter/RequestExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/RequestExecuter/RequestExecuter.swift
@@ -28,4 +28,7 @@ public protocol RequestExecuter {
      *  The request to be able to cancel it if necessary.
      */
     func send(request: URLRequest, _ completion: @escaping ((Data?, URLResponse?, Error?) -> Void)) -> CancellableRequest?
+
+    @available(iOS 15.0, macOS 12.0, *)
+    func send(request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data?, URLResponse?)
 }

--- a/Sources/Jetworking/Client/Executor/RequestExecuter/RequestExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/RequestExecuter/RequestExecuter.swift
@@ -29,6 +29,6 @@ public protocol RequestExecuter {
      */
     func send(request: URLRequest, _ completion: @escaping ((Data?, URLResponse?, Error?) -> Void)) -> CancellableRequest?
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     func send(request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data?, URLResponse?)
 }

--- a/Sources/Jetworking/Client/Executor/RequestExecuter/SyncRequestExecuter/SyncRequestExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/RequestExecuter/SyncRequestExecuter/SyncRequestExecuter.swift
@@ -20,7 +20,7 @@ final class SyncRequestExecuter: RequestExecuter {
         return operation
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     func send(request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data?, URLResponse?) {
         return (nil, nil)
     }

--- a/Sources/Jetworking/Client/Executor/RequestExecuter/SyncRequestExecuter/SyncRequestExecuter.swift
+++ b/Sources/Jetworking/Client/Executor/RequestExecuter/SyncRequestExecuter/SyncRequestExecuter.swift
@@ -19,4 +19,9 @@ final class SyncRequestExecuter: RequestExecuter {
 
         return operation
     }
+
+    @available(iOS 15.0, macOS 12.0, *)
+    func send(request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data?, URLResponse?) {
+        return (nil, nil)
+    }
 }

--- a/Sources/Jetworking/Client/ResponseHandler.swift
+++ b/Sources/Jetworking/Client/ResponseHandler.swift
@@ -29,6 +29,15 @@ final class ResponseHandler {
         evaluate(data: data, urlResponse: urlResponse, error: error, endpoint: endpoint, completionWrapper: makeDecodableCompletionWrapper, completion: completion)
     }
 
+    @available(iOS 15.0, macOS 12.0, *)
+    func handleDecodableResponse<ResponseType: Decodable>(
+        data: Data?,
+        urlResponse: URLResponse?,
+        endpoint: Endpoint<ResponseType>? = nil
+    ) async -> (HTTPURLResponse?, Result<ResponseType, Error>) {
+        await evaluate(data: data, urlResponse: urlResponse, endpoint: endpoint)
+    }
+
     private func makeVoidCompletionWrapper<ResponseType>(
         currentURLResponse: HTTPURLResponse?,
         data: Data?,
@@ -118,6 +127,54 @@ final class ResponseHandler {
 
         default:
             return
+        }
+    }
+
+    @available(iOS 13.0.0, macOS 12.0, *)
+    private func evaluate<ResponseType: Decodable>(
+        data: Data?,
+        urlResponse: URLResponse?,
+        endpoint: Endpoint<ResponseType>? = nil
+    ) async -> (HTTPURLResponse?, Result<ResponseType, Error>) {
+        let interceptedResponse = configuration.interceptors.reduce(urlResponse) { response, component in
+            return component.intercept(response: response, data: data, error: nil)
+        }
+
+        guard let currentURLResponse = interceptedResponse as? HTTPURLResponse else {
+            return (nil, .failure(APIError.responseMissing))
+        }
+
+        switch HTTPStatusCodeType(statusCode: currentURLResponse.statusCode) {
+        case .successful:
+            guard let data = data else { return (nil, .failure(APIError.missingResponseBody)) }
+            let decoder = endpoint?.decoder ?? configuration.decoder
+            do {
+                let responseType = try decoder.decode(ResponseType.self, from: data)
+                return (currentURLResponse, .success(responseType))
+            } catch {
+                return (nil, .failure(APIError.decodingError(error)))
+            }
+
+        case .serverError:
+            let apiError: APIError = APIError.serverError(
+                statusCode: currentURLResponse.statusCode,
+                error: nil,
+                body: data
+            )
+
+            return (currentURLResponse, .failure(apiError))
+
+        case .clientError:
+            let apiError: APIError = APIError.clientError(
+                statusCode: currentURLResponse.statusCode,
+                error: nil,
+                body: data
+            )
+
+            return (currentURLResponse, .failure(apiError))
+
+        default:
+            return (nil, .failure(APIError.unexpectedError))
         }
     }
 

--- a/Sources/Jetworking/Client/ResponseHandler.swift
+++ b/Sources/Jetworking/Client/ResponseHandler.swift
@@ -29,7 +29,7 @@ final class ResponseHandler {
         evaluate(data: data, urlResponse: urlResponse, error: error, endpoint: endpoint, completionWrapper: makeDecodableCompletionWrapper, completion: completion)
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     func handleDecodableResponse<ResponseType: Decodable>(
         data: Data?,
         urlResponse: URLResponse?,
@@ -130,7 +130,7 @@ final class ResponseHandler {
         }
     }
 
-    @available(iOS 13.0.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     private func evaluate<ResponseType: Decodable>(
         data: Data?,
         urlResponse: URLResponse?,

--- a/Sources/Jetworking/Extensions/Future+Extension.swift
+++ b/Sources/Jetworking/Extensions/Future+Extension.swift
@@ -1,0 +1,18 @@
+import Combine
+import Foundation
+
+@available(iOS 15.0, macOS 12.0, *)
+extension Future where Failure == Error {
+    convenience init(operation: @escaping () async throws -> Output) {
+        self.init { promise in
+            Task {
+                do {
+                    let output = try await operation()
+                    promise(.success(output))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+    }
+}

--- a/Sources/Jetworking/Extensions/Task+Extension.swift
+++ b/Sources/Jetworking/Extensions/Task+Extension.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+@available(iOS 15.0, macOS 12.0, *)
+extension Task where Failure == Error {
+    @discardableResult
+    static func retrying(
+        priority: TaskPriority? = nil,
+        maxRetryCount: Int = 3,
+        retryDelay: TimeInterval = 1,
+        operation: @Sendable @escaping () async throws -> Success
+    ) -> Task {
+        Task(priority: priority) {
+            for _ in 0..<maxRetryCount {
+                do {
+                    return try await operation()
+                } catch {
+                    let oneSecond = TimeInterval(1_000_000_000)
+                    let delay = UInt64(oneSecond * retryDelay)
+                    try await Task<Never, Never>.sleep(nanoseconds: delay)
+
+                    continue
+                }
+            }
+
+            try Task<Never, Never>.checkCancellation()
+            return try await operation()
+        }
+    }
+}

--- a/Sources/Jetworking/Extensions/URLSession+Extension.swift
+++ b/Sources/Jetworking/Extensions/URLSession+Extension.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+@available(iOS, deprecated: 15.0, message: "Use the built-in API instead")
+public extension URLSession {
+    /// Start a data task with a `URLRequest` using async/await.
+    /// - parameter request: The `URLRequest` that the data task should perform.
+    /// - returns: A tuple containing the binary `Data` that was downloaded,
+    ///   as well as a `URLResponse` representing the server's response.
+    /// - throws: Any error encountered while performing the data task.
+    @available(iOS 13.0, macOS 10.15.0, *)
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        var dataTask: URLSessionDataTask?
+        let onCancel = { dataTask?.cancel() }
+
+        return try await withTaskCancellationHandler(
+            handler: {
+                onCancel()
+            },
+            operation: {
+                try await withCheckedThrowingContinuation { continuation in
+                    dataTask = self.dataTask(with: request) { data, response, error in
+                        guard let data = data, let response = response else {
+                            let error = error ?? URLError(.badServerResponse)
+                            return continuation.resume(throwing: error)
+                        }
+
+                        continuation.resume(returning: (data, response))
+                    }
+
+                    dataTask?.resume()
+                }
+            }
+        )
+    }
+}

--- a/Tests/JetworkingTests/Mocks/MockExecuter.swift
+++ b/Tests/JetworkingTests/Mocks/MockExecuter.swift
@@ -54,7 +54,7 @@ final class MockExecuter: RequestExecuter {
         }
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 13.0, macOS 10.15.0, *)
     func send(request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data?, URLResponse?) {
         return (nil, nil)
     }

--- a/Tests/JetworkingTests/Mocks/MockExecuter.swift
+++ b/Tests/JetworkingTests/Mocks/MockExecuter.swift
@@ -54,6 +54,11 @@ final class MockExecuter: RequestExecuter {
         }
     }
 
+    @available(iOS 15.0, macOS 12.0, *)
+    func send(request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data?, URLResponse?) {
+        return (nil, nil)
+    }
+
     private func execute(
         request: URLRequest,
         completion: @escaping ((Data?, URLResponse?, Error?) -> Void)


### PR DESCRIPTION
### Description
With this PR the developers are able to use async await within their apps for network requests. It adds an API for GET, POST, PUT, PATCH, DELETE and a simple request. The body and response handling is adjusted to match the one where completion blocks are being used. Furthermore the possibility to use Combine was added to be able to include async network calls within a chain. Also, which can be discussed is the fact that retrying was added to the `Task` concurrency mechanism. Maybe we also want this for the completion API or we simply remove it as it won't be used for now. 

The state of the MR is currently WIP as we haven't yet decided what to do with the synchronous execution. Furthermore this is just a proposal which should be discussed within this PR.

### Additional Notes
The API is currently only available for iOS 13.0 and macOS 10.15 apps due to additional backward compatibility of `URLSession.dataTask`. 